### PR TITLE
Build.yml updates to fix package push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,14 +112,14 @@ jobs:
         working-directory: ./tooling/Scripts/
         run: ./PackEachExperiment.ps1 all
 
-      # Push Packages to our DevOps Artifacts Feed
+      # Push Packages to our DevOps Artifacts Feed (see nuget.config)
       - name: Add source
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: dotnet nuget add source "https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" --name ToolkitNightly --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
+        run: dotnet nuget update source MainLatest --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
 
       - name: Push packages
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: dotnet nuget push "**/*.nupkg" --api-key dummy --source ToolkitNightly --skip-duplicate
+        run: dotnet nuget push "**/*.nupkg" --api-key dummy --source MainLatest --skip-duplicate
 
       # Run tests
       - name: Setup VSTest Path


### PR DESCRIPTION
Fixes #21 (hopefully)

This PR does two things:
- attempts to turn on multiple cpu usage (will be interesting to see if helps with .NET Native or not too)
- hopefully fixes the updating of the NuGet.config now that our feed is defined there so we can push packages again

Switch to using [`update source`](https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-update-source) instead of our original `add` for the NuGet command.