### PR TITLE
Re-enable Testspaces Test Reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  merge_group:
 
 env:
   DOTNET_VERSION: ${{ '6.0.x' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,11 +125,10 @@ jobs:
       - name: Setup VSTest Path
         uses: darenm/Setup-VSTest@v1
 
-      # See https://github.com/CommunityToolkit/Windows/issues/3
-      # - name: Install Testspace Module
-      #   uses: testspace-com/setup-testspace@v1
-      #   with:
-      #     domain: ${{ github.repository_owner }}
+      - name: Install Testspace Module
+        uses: testspace-com/setup-testspace@v1
+        with:
+          domain: ${{ github.repository_owner }}
 
       - name: Run SourceGenerators tests
         id: test-generator
@@ -139,10 +138,10 @@ jobs:
         id: test-platform
         run:  vstest.console.exe ./tooling/**/CommunityToolkit.Tests.${{ env.TEST_PLATFORM }}.build.appxrecipe /Framework:FrameworkUap10 /logger:"trx;LogFileName=${{ env.TEST_PLATFORM }}.trx"
 
-      # - name: Create test reports
-      #   run: |
-      #     testspace '[${{ matrix.platform }}]./TestResults/*.trx'
-      #   if: ${{ always() && (steps.test-generator.conclusion == 'success' || steps.test-platform.conclusion == 'success') }}
+      - name: Create test reports
+        run: |
+          testspace '[${{ matrix.platform }}]./TestResults/*.trx'
+        if: ${{ always() && (steps.test-generator.conclusion == 'success' || steps.test-platform.conclusion == 'success') }}
 
       - name: Artifact - Diagnostic Logs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes #3

Pretty sure we just commented this out, now that the repo is public this should just work again. I added the repo back in the [TestSpace portal](https://communitytoolkit.testspace.com/).

Note: We'll need to add the checks in the branch protections once these are running:

![image](https://user-images.githubusercontent.com/24302614/233764960-e7d01ef1-326b-4103-af09-15b644ce66d7.png)

![image](https://user-images.githubusercontent.com/24302614/233764974-14ac8b5e-83cc-440f-9d3e-bda78de3075a.png)

The testspaces one (should appear searchable pretty easily once it has run once in the job _successfully_):

![image](https://user-images.githubusercontent.com/24302614/233766542-72141b3d-d77e-48af-9515-f3b69840b2e2.png)
