### PR TITLE
Fixed PackageId for control-based components

### DIFF
--- a/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
+++ b/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
@@ -11,7 +11,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj"></ProjectReference>
   </ItemGroup>
-  
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+
+  <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
 </Project>

--- a/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
+++ b/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
@@ -8,10 +8,14 @@
     <RootNamespace>CommunityToolkit.WinUI.Controls.RangeSelectorRns</RootNamespace>
   </PropertyGroup>
 
- <ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+
+  <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
 </Project>

--- a/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
+++ b/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
@@ -14,4 +14,8 @@
   <ItemGroup>
     <ProjectReference Include="$(ToolkitExtensionSourceProject)" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
 </Project>

--- a/components/Triggers/src/CommunityToolkit.WinUI.Controls.Triggers.csproj
+++ b/components/Triggers/src/CommunityToolkit.WinUI.Controls.Triggers.csproj
@@ -8,10 +8,14 @@
     <RootNamespace>CommunityToolkit.WinUI.Controls.TriggersRns</RootNamespace>
   </PropertyGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(ToolkitHelperSourceProject)" />
   </ItemGroup>
-  
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+
+  <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Progress towards #43. Several components mistakenly used the default PackageId, which simply uses the name of the component and did not include the `Controls` moniker:

![image](https://github.com/CommunityToolkit/Windows/assets/9384894/07860daf-0c9b-4c80-ab60-548d022b486e)

The already published packages being replaced will need to be marked as deprecated.



