### PR TITLE
[Chore] Removing controls in .csproj

### DIFF
--- a/components/Triggers/src/CommunityToolkit.WinUI.Triggers.csproj
+++ b/components/Triggers/src/CommunityToolkit.WinUI.Triggers.csproj
@@ -5,7 +5,7 @@
     <Version>8.0.0-beta.1</Version>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
-    <RootNamespace>CommunityToolkit.WinUI.Controls.TriggersRns</RootNamespace>
+    <RootNamespace>CommunityToolkit.WinUI.TriggersRns</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,6 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
   <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).$(ToolkitComponentName)</PackageId>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
`Triggers` was still referencing `CommunityToolkit.WinUI.Controls.Triggers` in the .csproj file. This PR removes the `Controls` part.