### PR TITLE
Fixes #85 - ContentSizer manipulating component Width to Zero on load

### DIFF
--- a/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
+++ b/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ToolkitComponentName>Sizers</ToolkitComponentName>
     <Description>This package contains SizerBase.</Description>
-    <Version>8.0.0-beta.1</Version>
+    <Version>8.0.0-beta.2</Version>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.SizersRns</RootNamespace>

--- a/components/Sizers/src/ContentSizer/ContentSizer.Properties.cs
+++ b/components/Sizers/src/ContentSizer/ContentSizer.Properties.cs
@@ -35,28 +35,5 @@ public partial class ContentSizer
     /// Identifies the <see cref="TargetControl"/> dependency property.
     /// </summary>
     public static readonly DependencyProperty TargetControlProperty =
-        DependencyProperty.Register(nameof(TargetControl), typeof(FrameworkElement), typeof(ContentSizer), new PropertyMetadata(null, OnTargetControlChanged));
-
-    private static void OnTargetControlChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        // TODO: Should we do this after the TargetControl is Loaded? (And use ActualWidth?)
-        // Or should we just do it in the manipulation event if Width is null?
-
-        // Check if our width can be manipulated
-        if (d is SizerBase splitterBase && e.NewValue is FrameworkElement element)
-        {
-            // TODO: For Auto ResizeDirection we might want to do detection logic (TBD) here first?
-            if (splitterBase.Orientation != Orientation.Horizontal && double.IsNaN(element.Width))
-            {
-                // We need to set the Width or Height somewhere,
-                // as if it's NaN we won't be able to manipulate it.
-                element.Width = element.DesiredSize.Width;
-            }
-
-            if (splitterBase.Orientation != Orientation.Vertical && double.IsNaN(element.Height))
-            {
-                element.Height = element.DesiredSize.Height;
-            }
-        }
-    }
+        DependencyProperty.Register(nameof(TargetControl), typeof(FrameworkElement), typeof(ContentSizer), new PropertyMetadata(null));
 }

--- a/components/Sizers/tests/ContentSizerTestInitialLayout.xaml
+++ b/components/Sizers/tests/ContentSizerTestInitialLayout.xaml
@@ -1,0 +1,20 @@
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="SizersExperiment.Tests.ContentSizerTestInitialLayout"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <TextBlock x:Name="TargetText"
+                   Text="This is some text" />
+        <controls:ContentSizer Grid.Column="1"
+                               TargetControl="{x:Bind TargetText}" />
+    </Grid>
+</Page>

--- a/components/Sizers/tests/ContentSizerTestInitialLayout.xaml.cs
+++ b/components/Sizers/tests/ContentSizerTestInitialLayout.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace SizersExperiment.Tests;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class ContentSizerTestInitialLayout : Page
+{
+    public ContentSizerTestInitialLayout()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Sizers/tests/ExampleSizerBaseTestClass.cs
+++ b/components/Sizers/tests/ExampleSizerBaseTestClass.cs
@@ -58,4 +58,17 @@ public partial class ExampleSizerBaseTestClass : VisualUITestBase
         // Set in XAML Page LINK: PropertySizerTestInitialBinding.xaml#L14
         Assert.AreEqual(200, propertySizer.Binding, "Property Sizer not at expected changed value.");
     }
+
+    [UIThreadTestMethod]
+    public void ContentSizer_TestAutoLayout_NonZeroAndNaN(ContentSizerTestInitialLayout testControl)
+    {
+        var contentSizer = testControl.FindDescendant<ContentSizer>();
+        var textBlock = testControl.FindDescendant<TextBlock>();
+
+        Assert.IsNotNull(contentSizer, "Could not find ContentSizer control.");
+        Assert.IsNotNull(textBlock, "Could not find TextBlock control.");
+
+        Assert.IsTrue(textBlock.DesiredSize.Width > 5, "TextBlock desired size is too small.");
+        Assert.IsTrue(double.IsNaN(textBlock.Width), "TextBlock width should not be constrained and be NaN.");
+    }
 }

--- a/components/Sizers/tests/Sizers.Tests.projitems
+++ b/components/Sizers/tests/Sizers.Tests.projitems
@@ -9,12 +9,19 @@
     <Import_RootNamespace>SizersExperiment.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ContentSizerTestInitialLayout.xaml.cs">
+      <DependentUpon>ContentSizerTestInitialLayout.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleSizerBaseTestClass.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PropertySizerTestInitialBinding.xaml.cs">
       <DependentUpon>PropertySizerTestInitialBinding.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)ContentSizerTestInitialLayout.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)PropertySizerTestInitialBinding.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
Fixes #85

ContentSizer was overwriting Width to Zero causing initial layout problems of a component, instead this code is removed as it is not needed to maintain the same behavior. Added a test to validate the old behavior was incorrect and the new desired behavior should work.

See more in linked issue of the details of this.

Basically, this PR:
- adds a unit test to validate the desired correct behavior (failing before, passing now).
- removes code which is unneeded for the proper functioning of the component anyway.
- bumps version number