### PR TITLE
Improved styling customization SizerBase

### DIFF
--- a/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
+++ b/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ToolkitComponentName>Sizers</ToolkitComponentName>
     <Description>This package contains SizerBase.</Description>
-    <Version>8.0.0-beta.2</Version>
+    <Version>8.0.0-beta.3</Version>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.SizersRns</RootNamespace>

--- a/components/Sizers/src/SizerBase.xaml
+++ b/components/Sizers/src/SizerBase.xaml
@@ -65,7 +65,6 @@
             <Setter.Value>
                 <ControlTemplate TargetType="controls:SizerBase">
                     <Grid x:Name="RootGrid"
-                          Margin="{TemplateBinding Margin}"
                           Background="{TemplateBinding Background}"
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"

--- a/components/Sizers/src/SizerBase.xaml
+++ b/components/Sizers/src/SizerBase.xaml
@@ -44,7 +44,7 @@
     <x:Double x:Key="SizerBaseThumbHeight">24</x:Double>
     <x:Double x:Key="SizerBaseThumbWidth">4</x:Double>
     <x:Double x:Key="SizerBaseThumbRadius">2</x:Double>
-    <Thickness x:Key="SizerBaseThumbMargin">4</Thickness>
+    <Thickness x:Key="SizerBasePadding">4</Thickness>
 
     <Style TargetType="controls:SizerBase">
         <Setter Property="IsTabStop" Value="True" />
@@ -54,6 +54,7 @@
         <Setter Property="IsFocusEngagementEnabled" Value="True" />
         <Setter Property="MinHeight" Value="8" />
         <Setter Property="MinWidth" Value="8" />
+        <Setter Property="Padding" Value="{ThemeResource SizerBasePadding}" />
         <Setter Property="Foreground" Value="{ThemeResource SizerBaseForeground}" />
         <Setter Property="Background" Value="{ThemeResource SizerBaseBackground}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -64,9 +65,11 @@
             <Setter.Value>
                 <ControlTemplate TargetType="controls:SizerBase">
                     <Grid x:Name="RootGrid"
+                          Margin="{TemplateBinding Margin}"
                           Background="{TemplateBinding Background}"
                           BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="{TemplateBinding BorderThickness}">
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          CornerRadius="{TemplateBinding CornerRadius}">
                         <Grid.BackgroundTransition>
                             <BrushTransition Duration="0:0:0.083" />
                         </Grid.BackgroundTransition>
@@ -112,7 +115,7 @@
                         <Rectangle x:Name="PART_Thumb"
                                    Width="{ThemeResource SizerBaseThumbWidth}"
                                    Height="{ThemeResource SizerBaseThumbHeight}"
-                                   Margin="{ThemeResource SizerBaseThumbMargin}"
+                                   Margin="{TemplateBinding Padding}"
                                    Fill="{TemplateBinding Foreground}"
                                    RadiusX="{ThemeResource SizerBaseThumbRadius}"
                                    RadiusY="{ThemeResource SizerBaseThumbRadius}" />


### PR DESCRIPTION
@michael-hawker pointed out that with the visual refresh we lost the ability to set the `Padding` and `CornerRadius`.

This PR introduces the following changes:
- Renaming `SizerBaseMargin` to `SizerBasePadding`
- The `Padding` and `CornerRadius` can now be set for better customization:

![image](https://github.com/CommunityToolkit/Windows/assets/9866362/87229dff-5d18-476c-9830-830c6cad93d4)
