### PR TITLE
Fix package id for CameraPreview

### DIFF
--- a/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
+++ b/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
@@ -14,4 +14,8 @@
 
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pr corrects the PackageId for the `CameraPreview` component. This component is in the `CommunityToolkit.WinUI.Controls` namespace, but the package ID was not set to reflect that.