### PR TITLE
Add sample/tests for FrameworkElementExtensions.Ancestor/Type

### DIFF
--- a/components/Extensions/samples/FrameworkElementAncestorSample.xaml
+++ b/components/Extensions/samples/FrameworkElementAncestorSample.xaml
@@ -1,0 +1,22 @@
+<Page x:Class="ExtensionsExperiment.Samples.FrameworkElementAncestorSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ExtensionsExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:ui="using:CommunityToolkit.WinUI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d">
+
+    <StackPanel Padding="16"
+                Spacing="{x:Bind ValueSlider.Value, Mode=OneWay}">
+        <Slider x:Name="ValueSlider"
+                Maximum="16"
+                Minimum="4"
+                StepFrequency="4"
+                Value="8" />
+        <TextBlock Text="This is some text in a StackPanel with Spacing:" />
+        <TextBlock ui:FrameworkElementExtensions.AncestorType="StackPanel"
+                   Text="{Binding (ui:FrameworkElementExtensions.Ancestor).Spacing, RelativeSource={RelativeSource Self}}" />
+    </StackPanel>
+</Page>

--- a/components/Extensions/samples/FrameworkElementAncestorSample.xaml.cs
+++ b/components/Extensions/samples/FrameworkElementAncestorSample.xaml.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ExtensionsExperiment.Samples;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+[ToolkitSample(id: nameof(FrameworkElementAncestorSample), nameof(FrameworkElementAncestorSample), description: $"A sample for showing how to use the FrameworkElementExtensions.Ancestor attached property.")]
+public sealed partial class FrameworkElementAncestorSample : Page
+{
+    public FrameworkElementAncestorSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Extensions/samples/FrameworkElementExtensions.md
+++ b/components/Extensions/samples/FrameworkElementExtensions.md
@@ -102,11 +102,9 @@ The `AncestorType` attached property will walk the visual tree from the attached
 
 Here is an example of how this can be used:
 
-```xaml
-<Button
-    ui:FrameworkElementExtensions.AncestorType="Grid"
-    Visibility="{Binding (ui:FrameworkElementExtensions.Ancestor).Visibility,RelativeSource={RelativeSource Self}}"/>
-```
+> [!SAMPLE FrameworkElementAncestorSample]
+
+While this example is trivial, it shows you how to properly setup and bind to the parent element's property, in this case `Spacing`.
 
 ## Cursor
 

--- a/components/Extensions/src/Element/FrameworkElementExtensions.Mouse.cs
+++ b/components/Extensions/src/Element/FrameworkElementExtensions.Mouse.cs
@@ -14,7 +14,7 @@ using CursorShape = Windows.UI.Core.CoreCursorType;
 namespace CommunityToolkit.WinUI;
 
 // TODO: Note: Windows App SDK doesn't support this (need to use Protected Cursor), but we still use this extension for Sizer controls.
-// For now rather than not porting, we'll just exclude on Windows App SDK platforms. Fenced other blocks below and support both equivelent types, but don't have a general way to set cursor on window yet in PointerEntered/Exited. If in end, FrameworkElement gets non-protected Cursor property like WPF, then this extension also isn't needed.
+// For now rather than not porting, we'll just exclude on Windows App SDK platforms. Fenced other blocks below and support both equivalent types, but don't have a general way to set cursor on window yet in PointerEntered/Exited. If in end, FrameworkElement gets non-protected Cursor property like WPF, then this extension also isn't needed.
 // See https://github.com/microsoft/microsoft-ui-xaml/issues/4834
 #if !WINAPPSDK
 

--- a/components/Extensions/src/Element/FrameworkElementExtensions.RelativeAncestor.cs
+++ b/components/Extensions/src/Element/FrameworkElementExtensions.RelativeAncestor.cs
@@ -78,6 +78,19 @@ public static partial class FrameworkElementExtensions
         if (sender is FrameworkElement fe)
         {
             SetAncestor(fe, fe.FindAscendant(GetAncestorType(fe))!);
+
+            fe.Unloaded -= FrameworkElement_Unloaded;
+            fe.Unloaded += FrameworkElement_Unloaded;
+        }
+    }
+
+    private static void FrameworkElement_Unloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement fe)
+        {
+            fe.Unloaded -= FrameworkElement_Unloaded;
+
+            SetAncestor(fe, null!);
         }
     }
 }

--- a/components/Extensions/src/Element/FrameworkElementExtensions.RelativeAncestor.cs
+++ b/components/Extensions/src/Element/FrameworkElementExtensions.RelativeAncestor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace CommunityToolkit.WinUI;
 
 /// <inheritdoc cref="FrameworkElementExtensions"/>
@@ -39,7 +37,7 @@ public static partial class FrameworkElementExtensions
     /// Gets the Type of Ancestor to look for from this element.
     /// </summary>
     /// <returns>Type of Ancestor to look for from this element</returns>
-    public static Type GetAncestorType(DependencyObject obj)
+    public static Type GetAncestorType(FrameworkElement obj)
     {
         return (Type)obj.GetValue(AncestorTypeProperty);
     }
@@ -47,7 +45,7 @@ public static partial class FrameworkElementExtensions
     /// <summary>
     /// Sets the <see cref="Type"/> to look for from this element and place in the <see cref="AncestorProperty"/>.
     /// </summary>
-    public static void SetAncestorType(DependencyObject obj, Type value)
+    public static void SetAncestorType(FrameworkElement obj, Type value)
     {
         obj.SetValue(AncestorTypeProperty, value);
     }

--- a/components/Extensions/tests/BitmapIconExtensionTestPage.xaml
+++ b/components/Extensions/tests/BitmapIconExtensionTestPage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="ExtensionsExperiment.Tests.BitmapIconExtensionTestPage"
+<Page x:Class="ExtensionsComponent.Tests.BitmapIconExtensionTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/Extensions/tests/BitmapIconExtensionTests.cs
+++ b/components/Extensions/tests/BitmapIconExtensionTests.cs
@@ -4,8 +4,6 @@
 
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
-using CommunityToolkit.WinUI;
-using ExtensionsExperiment.Tests;
 
 namespace ExtensionsComponent.Tests;
 

--- a/components/Extensions/tests/Element/FrameworkElementExtensionsTests.RelativeAncestor.cs
+++ b/components/Extensions/tests/Element/FrameworkElementExtensionsTests.RelativeAncestor.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Tests;
+using CommunityToolkit.Tooling.TestGen;
+
+namespace ExtensionsComponent.Tests;
+
+[TestClass]
+public partial class FrameworkElementExtensionsTests : VisualUITestBase
+{
+    [TestCategory("FrameworkElementExtension")]
+    [UIThreadTestMethod]
+    public void FrameworkElementExtension_RelativeAncestor_InDataTemplate(FrameworkElementRelativeAncestorDataTemplateTestPage page)
+    {
+        var list = page.FindDescendant<ListView>();
+
+        Assert.IsNotNull(list, "Couldn't find listview");
+
+        int count = 0;
+        foreach (var item in list.FindDescendants().OfType<TextBlock>())
+        {
+            count++;
+            Assert.AreEqual("Hello", item.Text, "Text didn't match binding of ancestor tag property");
+        }
+
+        Assert.AreEqual(3, count, "Didn't find three textblocks");
+    }
+}

--- a/components/Extensions/tests/Element/FrameworkElementExtensionsTests.RelativeAncestor.cs
+++ b/components/Extensions/tests/Element/FrameworkElementExtensionsTests.RelativeAncestor.cs
@@ -27,4 +27,128 @@ public partial class FrameworkElementExtensionsTests : VisualUITestBase
 
         Assert.AreEqual(3, count, "Didn't find three textblocks");
     }
+
+    [TestCategory("FrameworkElementExtension")]
+    [UIThreadTestMethod]
+    public async Task FrameworkElementExtension_RelativeAncestor_FreeParentBaseline(FrameworkElementRelativeAncestorDataTemplateTestPage page)
+    {
+        var text = page.FindDescendant<TextBox>();
+
+        Assert.IsNotNull(text, "Couldn't find TextBox");
+
+        // Grab a hold of a weak reference for TextBox so we can detect when it unloads.
+        WeakReference textRef = new(text);
+        text = null;
+
+        var parent = page.FindDescendant<Grid>();
+
+        Assert.IsNotNull(parent, "Couldn't find parent Grid");
+
+        // Remove all the children from the grid to simulate it unloading.
+        VisualTreeHelper.DisconnectChildrenRecursive(parent);
+        parent.Children.Clear();
+        parent = null;
+
+        // Wait for the Visual Tree to perform removals and clean-up
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        // Wait for the .NET Garbage Collector to clean up references
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        Assert.IsFalse(textRef.IsAlive, "TextBox is still alive...");
+    }
+
+    [TestCategory("FrameworkElementExtension")]
+    [UIThreadTestMethod]
+    public async Task FrameworkElementExtension_RelativeAncestor_FreeParent(FrameworkElementRelativeAncestorDataTemplateTestPage page)
+    {
+        var list = page.FindDescendant<ListView>();
+
+        Assert.IsNotNull(list, "Couldn't find listview");
+
+        // Grab a hold of a weak reference for ListView so we can detect when it unloads.
+        WeakReference listRef = new(list);
+        list = null;
+
+        // Remove all the children from the grid to simulate it unloading.
+        VisualTreeHelper.DisconnectChildrenRecursive(page);
+        page.Content = null;
+
+        // Wait for the Visual Tree to perform removals and clean-up
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        // Wait for the .NET Garbage Collector to clean up references
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        Assert.IsFalse(listRef.IsAlive, "ListView is still alive...");
+    }
+
+    [TestCategory("FrameworkElementExtension")]
+    [UIThreadTestMethod]
+    public async Task FrameworkElementExtension_RelativeAncestor_FreePageNavigation()
+    {
+        TaskCompletionSource<bool?> taskCompletionSource = new();
+        var frame = new Frame();
+        frame.Navigated += OnNavigated;
+
+        await LoadTestContentAsync(frame);
+
+        // Navigate to the new page.
+        frame.Navigate(typeof(FrameworkElementRelativeAncestorDataTemplateTestPage), null, new SuppressNavigationTransitionInfo());
+
+        async void OnNavigated(object sender, NavigationEventArgs e)
+        {
+            frame.Navigated -= OnNavigated;
+
+            // Wait for first Render pass
+            await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+            taskCompletionSource.SetResult(true);
+        }
+
+        // Wait for frame to navigate/load
+        var result = await taskCompletionSource.Task;
+        Assert.IsTrue(result, "Navigation didn't complete");
+
+        // Find the ListView we want to track
+
+        var list = frame.FindDescendant<ListView>();
+
+        Assert.IsNotNull(list, "Couldn't find listview");
+
+        // Grab a hold of a weak reference for ListView so we can detect when it unloads.
+        WeakReference listRef = new(list);
+        list = null;
+
+        TaskCompletionSource<bool?> taskCompletionSource2 = new();
+        frame.Navigated += OnNavigated2;
+
+        async void OnNavigated2(object sender, NavigationEventArgs e)
+        {
+            frame.Navigated -= OnNavigated2;
+
+            // Wait for first Render pass
+            await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+            taskCompletionSource2.SetResult(true);
+        }
+
+        // Navigate to any other page to unload our other one
+        frame.Navigate(typeof(BitmapIconExtensionTestPage), null, new SuppressNavigationTransitionInfo());
+
+        // Wait for navigation to complete
+        result = await taskCompletionSource2.Task;
+        Assert.IsTrue(result, "Navigation didn't complete 2");
+
+        // Wait for the Visual Tree to perform removals and clean-up
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        // Wait for the .NET Garbage Collector to clean up references
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        Assert.IsFalse(listRef.IsAlive, "ListView is still alive...");
+    }
 }

--- a/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml
+++ b/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml
@@ -8,8 +8,7 @@
       mc:Ignorable="d">
 
     <Grid>
-        <ListView x:Name="ListViewControl"
-                  Tag="Hello">
+        <ListView Tag="Hello">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <TextBlock ui:FrameworkElementExtensions.AncestorType="ListView"
@@ -20,5 +19,7 @@
             <x:String>2</x:String>
             <x:String>3</x:String>
         </ListView>
+        <!--  Another child to test clearing GC  -->
+        <TextBox />
     </Grid>
 </Page>

--- a/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml
+++ b/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml
@@ -1,0 +1,24 @@
+<Page x:Class="ExtensionsComponent.Tests.FrameworkElementRelativeAncestorDataTemplateTestPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:ui="using:CommunityToolkit.WinUI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d">
+
+    <Grid>
+        <ListView x:Name="ListViewControl"
+                  Tag="Hello">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock ui:FrameworkElementExtensions.AncestorType="ListView"
+                               Text="{Binding (ui:FrameworkElementExtensions.Ancestor).Tag, RelativeSource={RelativeSource Self}}" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <x:String>1</x:String>
+            <x:String>2</x:String>
+            <x:String>3</x:String>
+        </ListView>
+    </Grid>
+</Page>

--- a/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml.cs
+++ b/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml.cs
@@ -7,9 +7,9 @@ namespace ExtensionsComponent.Tests;
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.
 /// </summary>
-public sealed partial class BitmapIconExtensionTestPage : Page
+public sealed partial class FrameworkElementRelativeAncestorDataTemplateTestPage : Page
 {
-    public BitmapIconExtensionTestPage()
+    public FrameworkElementRelativeAncestorDataTemplateTestPage()
     {
         this.InitializeComponent();
     }

--- a/components/Extensions/tests/Extensions.Tests.projitems
+++ b/components/Extensions/tests/Extensions.Tests.projitems
@@ -15,10 +15,18 @@
     <Compile Include="$(MSBuildThisFileDirectory)BitmapIconExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DispatcherQueueExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DispatcherQueueTimerExtensionTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Element\FrameworkElementExtensionsTests.RelativeAncestor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Element\FrameworkElementRelativeAncestorDataTemplateTestPage.xaml.cs">
+      <DependentUpon>FrameworkElementRelativeAncestorDataTemplateTestPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ObjectWithNullableBoolProperty.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)BitmapIconExtensionTestPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Element\FrameworkElementRelativeAncestorDataTemplateTestPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
Adds a new sample for this extension, works on UWP and WASDK. Didn't test WASM yet.

Maybe should try adding a test too...

Not sure if any other info should be provided here, thoughts @Arlodotexe? These could be good things to start shoring up or finishing the docs/sample migration of.

Also fixes #106
Adds tests for #107 

Supersedes https://github.com/CommunityToolkit/WindowsCommunityToolkit/pull/4322