### PR TITLE
[Converters] Adding updated samples

### DIFF
--- a/components/Converters/samples/BoolNegationConverterSample.xaml
+++ b/components/Converters/samples/BoolNegationConverterSample.xaml
@@ -12,6 +12,6 @@
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
     </Page.Resources>
 
-    <ToggleSwitch Header="Converted value"
-                  IsOn="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
+    <Button Content="Inverted value set as IsEnabled"
+            IsEnabled="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
 </Page>

--- a/components/Converters/samples/BoolNegationConverterSample.xaml
+++ b/components/Converters/samples/BoolNegationConverterSample.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ConvertersExperiment.Samples.StringFormatConverterSample"
+<Page x:Class="ConvertersExperiment.Samples.BoolNegationConverterSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:converters="using:CommunityToolkit.WinUI.Converters"
@@ -9,12 +9,9 @@
       mc:Ignorable="d">
 
     <Page.Resources>
-        <converters:StringFormatConverter x:Key="StringFormatConverter" />
+        <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
     </Page.Resources>
 
-    <StackPanel Spacing="16">
-        <TextBlock Text="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='The page is loading: {0}'}" />
-
-        <TextBlock Text="{x:Bind MyDoubleValue, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}There are {0:0.##} pixels'}" />
-    </StackPanel>
+    <ToggleSwitch Header="Converted value"
+                  IsOn="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
 </Page>

--- a/components/Converters/samples/BoolNegationConverterSample.xaml.cs
+++ b/components/Converters/samples/BoolNegationConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleBoolOption("MyBooleanValue", true, Title = "Original value")]
+
+[ToolkitSample(id: nameof(BoolNegationConverterSample), "BoolNegationConverter", description: $"A sample for showing how to use the BoolNegationConverter.")]
+public sealed partial class BoolNegationConverterSample : Page
+{
+    public BoolNegationConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/BoolToObjectConverterSample.xaml
+++ b/components/Converters/samples/BoolToObjectConverterSample.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ConvertersExperiment.Samples.StringFormatConverterSample"
+<Page x:Class="ConvertersExperiment.Samples.BoolToObjectConverterSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:converters="using:CommunityToolkit.WinUI.Converters"
@@ -9,12 +9,14 @@
       mc:Ignorable="d">
 
     <Page.Resources>
-        <converters:StringFormatConverter x:Key="StringFormatConverter" />
+        <converters:BoolToObjectConverter x:Key="BoolToObjectConverter"
+                                          FalseValue="{ThemeResource ControlStrongFillColorDefaultBrush}"
+                                          TrueValue="{ThemeResource AccentFillColorDefaultBrush}" />
     </Page.Resources>
 
-    <StackPanel Spacing="16">
-        <TextBlock Text="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='The page is loading: {0}'}" />
-
-        <TextBlock Text="{x:Bind MyDoubleValue, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}There are {0:0.##} pixels'}" />
-    </StackPanel>
+    <Border Width="64"
+            Height="64"
+            HorizontalAlignment="Left"
+            Background="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource BoolToObjectConverter}}"
+            CornerRadius="4" />
 </Page>

--- a/components/Converters/samples/BoolToObjectConverterSample.xaml.cs
+++ b/components/Converters/samples/BoolToObjectConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleBoolOption("MyBooleanValue", false, Title = "Toggle to change colors")]
+
+[ToolkitSample(id: nameof(BoolToObjectConverterSample), "BoolToObjectConverter", description: $"A sample for showing how to use the BoolToObjectConverter.")]
+public sealed partial class BoolToObjectConverterSample : Page
+{
+    public BoolToObjectConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/BoolToVisibilityConverterSample.xaml
+++ b/components/Converters/samples/BoolToVisibilityConverterSample.xaml
@@ -1,0 +1,27 @@
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="ConvertersExperiment.Samples.BoolToVisibilityConverterSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ConvertersExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
+                                              FalseValue="Collapsed"
+                                              TrueValue="Visible" />
+    </Page.Resources>
+
+    <Grid Width="64"
+          Height="64"
+          HorizontalAlignment="Left"
+          Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+          BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+          BorderThickness="1">
+        <Image HorizontalAlignment="Left"
+               Source="/Assets/Converters.png"
+               Visibility="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+    </Grid>
+</Page>

--- a/components/Converters/samples/BoolToVisibilityConverterSample.xaml.cs
+++ b/components/Converters/samples/BoolToVisibilityConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleBoolOption("MyBooleanValue", true, Title = "Toggle to show or hide the image")]
+
+[ToolkitSample(id: nameof(BoolToVisibilityConverterSample), "BoolToVisibilityConverter", description: $"A sample for showing how to use the BoolToVisibilityConverter.")]
+public sealed partial class BoolToVisibilityConverterSample : Page
+{
+    public BoolToVisibilityConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/CollectionVisibilityConverterSample.xaml
+++ b/components/Converters/samples/CollectionVisibilityConverterSample.xaml
@@ -1,0 +1,40 @@
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="ConvertersExperiment.Samples.CollectionVisibilityConverterSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ConvertersExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:CollectionVisibilityConverter x:Key="CollectionVisibilityConverter"
+                                                  EmptyValue="Visible"
+                                                  NotEmptyValue="Collapsed" />
+    </Page.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="120" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ListView Header="Lalala"
+                  ItemsSource="{x:Bind Items, Mode=OneWay}"
+                  Visibility="{Binding Path=Items, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}" />
+
+        <TextBlock Text="No items in this list"
+                   Visibility="{x:Bind Items, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}" />
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    Spacing="16">
+
+            <Button Click="Add_Click"
+                    Content="Add items" />
+            <Button Click="Clear_Click"
+                    Content="Clear items" />
+        </StackPanel>
+    </Grid>
+</Page>

--- a/components/Converters/samples/CollectionVisibilityConverterSample.xaml
+++ b/components/Converters/samples/CollectionVisibilityConverterSample.xaml
@@ -22,7 +22,7 @@
 
         <ListView Header="Lalala"
                   ItemsSource="{x:Bind Items, Mode=OneWay}"
-                  Visibility="{Binding Path=Items, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}" />
+                  Visibility="{x:Bind Items, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}" />
 
         <TextBlock Text="No items in this list"
                    Visibility="{x:Bind Items, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}" />

--- a/components/Converters/samples/CollectionVisibilityConverterSample.xaml.cs
+++ b/components/Converters/samples/CollectionVisibilityConverterSample.xaml.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSample(id: nameof(CollectionVisibilityConverterSample), "CollectionVisibilityConverter", description: $"A sample for showing how to use the CollectionVisibilityConverter.")]
+public sealed partial class CollectionVisibilityConverterSample : Page
+{
+    public ObservableCollection<string> Items { get; set; }
+
+    public CollectionVisibilityConverterSample()
+    {
+        this.InitializeComponent();
+        Items = new();
+
+
+    }
+
+    private void Add_Click(object sender, RoutedEventArgs e)
+    {
+        Items.Clear();
+        Items.Add("Item 1");
+        Items.Add("Item 2");
+        Items.Add("Item 3");
+    }
+
+    private void Clear_Click(object sender, RoutedEventArgs e)
+    {
+        Items.Clear();
+    }
+}

--- a/components/Converters/samples/CollectionVisibilityConverterSample.xaml.cs
+++ b/components/Converters/samples/CollectionVisibilityConverterSample.xaml.cs
@@ -7,26 +7,10 @@ namespace ConvertersExperiment.Samples;
 [ToolkitSample(id: nameof(CollectionVisibilityConverterSample), "CollectionVisibilityConverter", description: $"A sample for showing how to use the CollectionVisibilityConverter.")]
 public sealed partial class CollectionVisibilityConverterSample : Page
 {
-    public ObservableCollection<string> Items { get; set; }
+    public ObservableCollection<string> EmptyCollection = new();
 
     public CollectionVisibilityConverterSample()
     {
         this.InitializeComponent();
-        Items = new();
-
-
-    }
-
-    private void Add_Click(object sender, RoutedEventArgs e)
-    {
-        Items.Clear();
-        Items.Add("Item 1");
-        Items.Add("Item 2");
-        Items.Add("Item 3");
-    }
-
-    private void Clear_Click(object sender, RoutedEventArgs e)
-    {
-        Items.Clear();
     }
 }

--- a/components/Converters/samples/ColorToDisplayNameConverterSample.xaml
+++ b/components/Converters/samples/ColorToDisplayNameConverterSample.xaml
@@ -1,0 +1,32 @@
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="ConvertersExperiment.Samples.ColorToDisplayNameConverterSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ConvertersExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:ColorToDisplayNameConverter x:Key="ColorToDisplayNameConverter" />
+    </Page.Resources>
+
+    <StackPanel HorizontalAlignment="Left"
+                Spacing="16">
+
+        <ColorPicker x:Name="colorPicker"
+                     Height="64"
+                     VerticalAlignment="Top"
+                     ColorSpectrumShape="Box"
+                     IsAlphaEnabled="False"
+                     IsAlphaSliderVisible="True"
+                     IsAlphaTextInputVisible="True"
+                     IsColorChannelTextInputVisible="False"
+                     IsColorSliderVisible="False"
+                     IsHexInputVisible="False"
+                     IsMoreButtonVisible="False" />
+        <TextBlock Text="{Binding ElementName=colorPicker, Path=Color, Converter={StaticResource ColorToDisplayNameConverter}}" />
+    </StackPanel>
+</Page>

--- a/components/Converters/samples/ColorToDisplayNameConverterSample.xaml.cs
+++ b/components/Converters/samples/ColorToDisplayNameConverterSample.xaml.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSample(id: nameof(ColorToDisplayNameConverterSample), "ColorToDisplayNameConverter", description: $"A sample for showing how to use the ColorToDisplayNameConverter.")]
+public sealed partial class ColorToDisplayNameConverterSample : Page
+{
+    public ColorToDisplayNameConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/Converters.Samples.csproj
+++ b/components/Converters/samples/Converters.Samples.csproj
@@ -6,7 +6,15 @@
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
   <ItemGroup>
+    <None Remove="Assets\Converters.png" />
+  </ItemGroup>
+  <ItemGroup>
     <UpToDateCheckInput Remove="StringFormatConverterSample.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\Converters.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="StringFormatConverterSample.xaml.cs">

--- a/components/Converters/samples/Converters.md
+++ b/components/Converters/samples/Converters.md
@@ -18,19 +18,16 @@ Converts a boolean to the inverse value (True to False and vice versa)
 > [!Sample BoolNegationConverterSample]
 
 ## BoolToObjectConverter
-
 Converts a boolean value into an other object. Can be used to convert true/false to e.g. visibility, color, or different images.
 
 > [!Sample BoolToObjectConverterSample]
 
 ## BoolToVisibilityConverter
-
  Converts a boolean value into a `Visibility` enumeration. The `ConverterParameter` can be used to invert the logic.
 
 > [!Sample BoolToVisibilityConverterSample]
 
 ## ColorToDisplayNameConverter
-
 Converts a color to the approximated display name.
 
 > [!Sample ColorToDisplayNameConverterSample]
@@ -82,6 +79,4 @@ Returns an object or another, depending on whether the type of the provided valu
 > [!Sample TypeToObjectConverterSample]
 
 ## VisibilityToBoolConverter
-
 Converts a `Visibility` enumaration to a boolean value.
-

--- a/components/Converters/samples/Converters.md
+++ b/components/Converters/samples/Converters.md
@@ -12,151 +12,76 @@ issue-id: 0
 icon: Assets/Converters.png
 ---
 
-| Converter | Purpose |
-| --- | --- |
-| [BoolNegationConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.boolnegationconverter?view=uwp-toolkit-dotnet) | Converts a boolean to the inverse value (True to False and vice versa) |
-| [BoolToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.booltoobjectconverter?view=uwp-toolkit-dotnet) | Converts a boolean value into an object. The converted value is selected between the values of TrueValue and FalseValue properties |
-| [BoolToVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.booltovisibilityconverter?view=uwp-toolkit-dotnet) | Converts a boolean value into a Visibility enumeration |
-| [CollectionVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.collectionvisibilityconverter?view=uwp-toolkit-dotnet) | Converts a collection into a Visibility enumeration (Collapsed if the given collection is empty or null) |
-| [DoubleToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.doubletoobjectconverter?view=uwp-toolkit-dotnet) | Converts a double value into an object based on a value to be greater than, less than, or in-between. |
-| [DoubleToVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.doubletovisibilityconverter?view=uwp-toolkit-dotnet) | Converts a double value into a Visibility enumeration based on a value to be greater than, less than, or in-between. |
-| [EmptyCollectionToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptycollectiontoobjectconverter?view=uwp-toolkit-dotnet) | Converts a collection into an object. The converted value is selected between the values of EmptyValue and NotEmptyValue properties |
-| [EmptyObjectToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptyobjecttoobjectconverter?view=uwp-toolkit-dotnet) | Converts a check on a null value into an object. The converted value is selected between the values of EmptyValue and NonEmptyValue properties |
-| [EmptyStringToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptystringtoobjectconverter?view=uwp-toolkit-dotnet) | Converts a string into an object. The converted value is selected between the values of EmptyValue and NotEmptyValue properties |
-| [FormatStringConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.formatstringconverter?view=uwp-toolkit-dotnet) | Converts an [IFormattable](/dotnet/api/system.string.format?view=netframework-4.7) value into a string. The ConverterParameter provides the string format |
-| [ResourceNameToResourceStringConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.resourcenametoresourcestringconverter?view=uwp-toolkit-dotnet) | Converter to look up the source string in the App Resources strings and returns its value, if found |
-| [StringFormatConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.stringformatconverter?view=uwp-toolkit-dotnet) | Converts a source object to the formatted string version using [string.Format](/dotnet/api/system.string.format?view=netframework-4.7). The ConverterParameter provides the string format |
-| [StringVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.stringvisibilityconverter?view=uwp-toolkit-dotnet) | Converts a string value into a Visibility enumeration (if the value is null or empty returns a collapsed value) |
-| [ToolbarFormatActiveConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.toolbarformatactiveconverter?view=uwp-toolkit-dotnet) | Compares if Formats are equal and returns bool |
-| [VisibilityToBoolConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.visibilitytoboolconverter?view=uwp-toolkit-dotnet) | This class converts a Visibility enumeration to a boolean value |
+## BoolNegationConverter
+Converts a boolean to the inverse value (True to False and vice versa)
 
-## BoolToObjectConverter Examples
+> [!Sample BoolNegationConverterSample]
 
-`BoolToObjectConverter` can be used to generalize the behavior of `BoolToVisibilityConverter` by allowing to pass the two values it can return.
-You can use it to switch Visibility by declaring it :
+## BoolToObjectConverter
 
-```xaml
-<Page ...
-     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"/>
+Converts a boolean value into an other object. Can be used to convert true/false to e.g. visibility, color, or different images.
 
-<Page.Resources>
-    <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
-</Page.Resources>
-```
+> [!Sample BoolToObjectConverterSample]
 
-and using it like that :
+## BoolToVisibilityConverter
 
-```xaml
-<Image Visibility="{x:Bind Path=MyBoolValue, Converter={StaticResource BoolToVisibilityConverter}}" />
-```
+ Converts a boolean value into a `Visibility` enumeration. The `ConverterParameter` can be used to invert the logic.
 
-It can also be used to switch between two values of brush.
+> [!Sample BoolToVisibilityConverterSample]
 
-Note : you can use a resource for the brush or pass the color string and have it converted to a brush automatically.
+## ColorToDisplayNameConverter
 
-```xaml
-<Page.Resources>
-    <converters:BoolToObjectConverter x:Key="BoolToBrushConverter" TrueValue="Green" FalseValue="{StaticResource NopeBrush}" />
-</Page.Resources>
-```
+Converts a color to the approximated display name.
 
-and using it like that :
+> [!Sample ColorToDisplayNameConverterSample]
 
-```xaml
-<Border Background="{x:Bind Path=MyBoolValue, Converter={StaticResource BoolToBrushConverter}}" />
-```
+## DoubleToObjectConverter
+Converts a double value into an other object. Can be used to convert doubles to e.g. visibility, colors , or different images. If `GreaterThan` and `LessThan` are both set, the logic looks for a value between the two values. Otherwise the logic looks for the value to be `GreaterThan` or `LessThan` the specified value. The `ConverterParameter` can be used to invert the logic.
 
-An other example is to switch between two images by specifying their source :
+> [!Sample DoubleToObjectConverterSample]
 
-```xaml
-<Page.Resources>
-    <converters:BoolToObjectConverter x:Key="BoolToImageConverter" TrueValue="ms-appx:///Assets/Yes.png" FalseValue="ms-appx:///Assets/No.png" />
-</Page.Resources>
-```
+## DoubleToVisibilityConverter
+Converts a double value into an other object. Can be used to convert doubles to e.g. visibility, colors , or different images. If `GreaterThan` and `LessThan` are both set, the logic looks for a value between the two values. Otherwise the logic looks for the value to be `GreaterThan` or `LessThan` the specified value. The `ConverterParameter` can be used to invert the logic.
 
-and using it like that :
+> [!Sample DoubleToVisibilityConverterSample]
 
-```xaml
-<Image Source="{x:Bind Path=MyBoolValue, Converter={StaticResource BoolToImageConverter}}" />
-```
+## EmptyCollectionToObjectConverter & CollectionVisibilityConverter
+Converts a collection size into an other object. Can be used to convert to bind a visibility, a color or an image to the size of the collection. The `CollectionVisibilityConverter` is derived from it and can be easily used to convert a collection into a `Visibility` enumeration (Collapsed if the given collection is empty or null).
 
-## BoolToVisibilityConverter Examples
+> [!Sample CollectionVisibilityConverterSample]
 
-`BoolToVisibilityConverter` can be used to easily change a boolean value to a Visibility based one.
-If targeting 14393 or later, this is done automatically through [x:Bind](/windows/uwp/xaml-platform/x-bind-markup-extension).  First, declare the converter in your resources:
+## EmptyObjectToObjectConverter, EmptyStringToObjectConverter & StringToVisibilityConverter
+Converts an object value into a an object (if the value is null returns the false value). Can be used to bind a visibility, a color or an image to the value of an object.
+The `EmptyStringToObjectConverter` converts a string value into a an object (if the value is null or empty returns the false value). Can be used to bind a visibility, a color or an image to the value of a string.
 
-```xaml
-<Page.Resources>
-    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
-</Page.Resources>
-```
+> [!Sample EmptyStringToObjectConverterSample]
 
-and use it like this :
+## FileSizeToFriendlyStringConverter
+Converts a file size in bytes to a more human-readable friendly format using ToFileSizeString(Int64).
 
-```xaml
-<Image Visibility="{Binding Path=MyBoolValue, Converter={StaticResource BoolToVisibilityConverter}}" />
-```
+## ResourceNameToResourceStringConverter
+Converts a source string from the App resources and returns its value, if found.
 
-you can also invert the boolean as a ConverterParameter:
-
-```xaml
-<Image Visibility="{Binding Path=MyBoolValue, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=True}" />
-```
-
-or if you want to not pass a parameter, you can use `BoolToObjectConverter` to create an `InverseBoolToVisibilityConveter`:
-
-```xaml
-<Page.Resources>
-    <converters:BoolToObjectConverter x:Key="InverseBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
-</Page.Resources>
-```
-
-## DoubleToVisibilityConverter Examples
-
-`DoubleToVisibilityConverter` can be used to easily change a double value to a Visibility based one based on a given threshold value.  If both `GreaterThan` and `LessThan` are set, the converter will set the visibility if the target value is in-between those two values.  Otherwise, it will look for the target being greater than or less than the specified value.
-
-If a `True` value is provided for a `ConverterParameter` than the equation will be inverted.
-
-```xaml
-<Page.Resources>
-    <converters:DoubleToVisibilityConverter x:Key="GreaterThanToleranceVisibilityConverter" GreaterThan="65.0"/>
-</Page.Resources>
-```
-
-and use it like this :
-
-```xaml
-<Button x:Name="ScrollBackButton"
-        Visibility="{Binding ScrollableWidth, Converter={StaticResource GreaterThanToleranceVisibilityConverter}, ElementName=ScrollViewer, FallbackValue=Collapsed, TargetNullValue=Collapsed}"/>
-```
-
-## EmptyObjectToObjectConverter Examples
-
-`EmptyObjectToObjectConverter`, `EmptyCollectionToObjectConverter`, and `EmptyStringToObjectConverter` work similarly to the `BoolToObjectConverter` except using `EmptyValue` and `NotEmptyValue` instead of `TrueValue`/`FalseValue`.
-
-They inspect the type of 'empty'/null object value and return the specific value `EmptyValue` or `NotEmptyValue` based on the result.
-That result can also be inverted withe a ConverterParameter.
-
-For instance you can generalize the `CollectionVisibilityConverter` using the `EmptyCollectionToObjectConverter`:
-
-```xaml
-<Page.Resources>
-    <converters:EmptyCollectionToObjectConverter x:Key="CollectionVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
-</Page.Resources>
-```
-
-this can be used as follows to hide a list with no items and instead show text through inversion with the ConverterParameter:
-
-```xaml
-<ListView Visibility="{Binding Path=MyCollectionValue, Converter={StaticResource CollectionVisibilityConverter}}" />
-
-<TextBlock Text="No Items." Visibility="{Binding Path=MyCollectionValue, Converter={StaticResource CollectionVisibilityConverter}, ConverterParameter=True}">
-```
-
-## StringFormatConverter Examples
-
-`StringFormatConverter` allows you to format a string property upon binding wrapping [string.Format](/dotnet/api/system.string.format?view=netstandard-2.0).  
+## StringFormatConverter
+This allows you to format a string property upon binding wrapping [string.Format](/dotnet/api/system.string.format?view=netstandard-2.0).  
 It only allows for a single input value (the binding string), but can be formatted with the regular string.Format
-methods.  First, add it to your page resources:
+methods.
 
 > [!Sample StringFormatConverterSample]
+
+## StringVisibilityConverter
+Converts a string value into a Visibility value (if the value is null or empty returns a collapsed value).
+
+> [!Sample StringVisibilityConverterSample]
+
+## TaskResultConverter
+Converter that can be used to safely retrieve results from `Task<TResult>` instances. See MVVM Toolkit Gallery for an example.
+
+## TypeToObjectConverter
+Returns an object or another, depending on whether the type of the provided value matches another provided Type.
+> [!Sample TypeToObjectConverterSample]
+
+## VisibilityToBoolConverter
+
+Converts a `Visibility` enumaration to a boolean value.
+

--- a/components/Converters/samples/Converters.md
+++ b/components/Converters/samples/Converters.md
@@ -12,6 +12,8 @@ issue-id: 0
 icon: Assets/Converters.png
 ---
 
+Converters are an easy way to handle situations where the source and target properties are of a different type. These are often declared in the `.Resources` of your app or page and can be referenced in XAML. In some cases, default converter values can be inverted by setting `ConverterParameter=True`.
+
 ## BoolNegationConverter
 Converts a boolean to the inverse value (True to False and vice versa)
 
@@ -33,17 +35,18 @@ Converts a color to the approximated display name.
 > [!Sample ColorToDisplayNameConverterSample]
 
 ## DoubleToObjectConverter
-Converts a double value into an other object. Can be used to convert doubles to e.g. visibility, colors , or different images. If `GreaterThan` and `LessThan` are both set, the logic looks for a value between the two values. Otherwise the logic looks for the value to be `GreaterThan` or `LessThan` the specified value. The `ConverterParameter` can be used to invert the logic.
+Converts a double value into an other object. Can be used to convert doubles to e.g. visibility, colors , or different images. If `GreaterThan` and `LessThan` are both set, the logic looks for a value between the two values. Otherwise the logic looks for the value to be `GreaterThan` or `LessThan` the specified value.
 
 > [!Sample DoubleToObjectConverterSample]
 
 ## DoubleToVisibilityConverter
-Converts a double value into an other object. Can be used to convert doubles to e.g. visibility, colors , or different images. If `GreaterThan` and `LessThan` are both set, the logic looks for a value between the two values. Otherwise the logic looks for the value to be `GreaterThan` or `LessThan` the specified value. The `ConverterParameter` can be used to invert the logic.
+Converts a double value into an other object. Can be used to convert doubles to e.g. visibility, colors , or different images. If `GreaterThan` and `LessThan` are both set, the logic looks for a value between the two values. Otherwise the logic looks for the value to be `GreaterThan` or `LessThan` the specified value.
 
 > [!Sample DoubleToVisibilityConverterSample]
 
 ## EmptyCollectionToObjectConverter & CollectionVisibilityConverter
 Converts a collection size into an other object. Can be used to convert to bind a visibility, a color or an image to the size of the collection. The `CollectionVisibilityConverter` is derived from it and can be easily used to convert a collection into a `Visibility` enumeration (Collapsed if the given collection is empty or null).
+Note: this converter only checks the initial state of a collection and does not detect any updates. For that scenario, using a `IsNullOrEmptyStateTrigger` is more appropriate. 
 
 > [!Sample CollectionVisibilityConverterSample]
 
@@ -54,7 +57,9 @@ The `EmptyStringToObjectConverter` converts a string value into a an object (if 
 > [!Sample EmptyStringToObjectConverterSample]
 
 ## FileSizeToFriendlyStringConverter
-Converts a file size in bytes to a more human-readable friendly format using ToFileSizeString(Int64).
+Converts a file size in bytes to a more human-readable friendly format using `ToFileSizeString(Int64)`.
+
+> [!Sample FileSizeToFriendlyStringConverterSample]
 
 ## ResourceNameToResourceStringConverter
 Converts a source string from the App resources and returns its value, if found.
@@ -72,7 +77,7 @@ Converts a string value into a Visibility value (if the value is null or empty r
 > [!Sample StringVisibilityConverterSample]
 
 ## TaskResultConverter
-Converter that can be used to safely retrieve results from `Task<TResult>` instances. See MVVM Toolkit Gallery for an example.
+Converter that can be used to safely retrieve results from `Task<TResult>` instances. See the [MVVM Toolkit Gallery](https://www.microsoft.com/store/productId/9NKLCF1LVZ5H) for an example.
 
 ## TypeToObjectConverter
 Returns an object or another, depending on whether the type of the provided value matches another provided Type.
@@ -80,3 +85,5 @@ Returns an object or another, depending on whether the type of the provided valu
 
 ## VisibilityToBoolConverter
 Converts a `Visibility` enumaration to a boolean value.
+
+> [!Sample VisibilityToBoolConverterSample]

--- a/components/Converters/samples/Converters.md
+++ b/components/Converters/samples/Converters.md
@@ -77,7 +77,7 @@ Converts a string value into a Visibility value (if the value is null or empty r
 > [!Sample StringVisibilityConverterSample]
 
 ## TaskResultConverter
-Converter that can be used to safely retrieve results from `Task<TResult>` instances. See the [MVVM Toolkit Gallery](https://www.microsoft.com/store/productId/9NKLCF1LVZ5H) for an example.
+Converter that can be used to safely retrieve results from `Task<TResult>` instances. See the [MVVM Toolkit Gallery](https://aka.ms/mvvmtoolkit/app) for an example.
 
 ## TypeToObjectConverter
 Returns an object or another, depending on whether the type of the provided value matches another provided Type.

--- a/components/Converters/samples/DoubleToObjectConverterSample.xaml
+++ b/components/Converters/samples/DoubleToObjectConverterSample.xaml
@@ -11,8 +11,8 @@
     <Page.Resources>
         <converters:DoubleToObjectConverter x:Key="DoubleToObjectConverter"
                                             FalseValue="{ThemeResource SystemFillColorSuccessBrush}"
-                                            GreaterThan="6"
-                                            LessThan="4"
+                                            GreaterThan="7"
+                                            LessThan="3"
                                             TrueValue="{ThemeResource SystemFillColorCriticalBrush}" />
     </Page.Resources>
 

--- a/components/Converters/samples/DoubleToObjectConverterSample.xaml
+++ b/components/Converters/samples/DoubleToObjectConverterSample.xaml
@@ -1,0 +1,24 @@
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="ConvertersExperiment.Samples.DoubleToObjectConverterSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ConvertersExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:DoubleToObjectConverter x:Key="DoubleToObjectConverter"
+                                            FalseValue="{ThemeResource SystemFillColorSuccessBrush}"
+                                            GreaterThan="6"
+                                            LessThan="4"
+                                            TrueValue="{ThemeResource SystemFillColorCriticalBrush}" />
+    </Page.Resources>
+
+    <Border Width="64"
+            Height="64"
+            HorizontalAlignment="Left"
+            Background="{x:Bind NumericValue, Mode=OneWay, Converter={StaticResource DoubleToObjectConverter}}"
+            CornerRadius="4" />
+</Page>

--- a/components/Converters/samples/DoubleToObjectConverterSample.xaml.cs
+++ b/components/Converters/samples/DoubleToObjectConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleNumericOption("NumericValue", 0, 0, 10, 1, false, Title = "Number")]
+
+[ToolkitSample(id: nameof(DoubleToObjectConverterSample), "DoubleToObjectConverter", description: $"A sample for showing how to use the DoubleToObjectConverter.")]
+public sealed partial class DoubleToObjectConverterSample : Page
+{
+    public DoubleToObjectConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/DoubleToVisibilityConverterSample.xaml
+++ b/components/Converters/samples/DoubleToVisibilityConverterSample.xaml
@@ -1,0 +1,28 @@
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="ConvertersExperiment.Samples.DoubleToVisibilityConverterSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ConvertersExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:DoubleToObjectConverter x:Key="DoubleToVisibilityConverter"
+                                            FalseValue="Collapsed"
+                                            GreaterThan="5"
+                                            TrueValue="Visible" />
+    </Page.Resources>
+
+    <Grid Width="64"
+          Height="64"
+          HorizontalAlignment="Left"
+          Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+          BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+          BorderThickness="1">
+        <Image HorizontalAlignment="Left"
+               Source="/Assets/Converters.png"
+               Visibility="{x:Bind NumericValue, Mode=OneWay, Converter={StaticResource DoubleToVisibilityConverter}}" />
+    </Grid>
+</Page>

--- a/components/Converters/samples/DoubleToVisibilityConverterSample.xaml
+++ b/components/Converters/samples/DoubleToVisibilityConverterSample.xaml
@@ -9,10 +9,8 @@
       mc:Ignorable="d">
 
     <Page.Resources>
-        <converters:DoubleToObjectConverter x:Key="DoubleToVisibilityConverter"
-                                            FalseValue="Collapsed"
-                                            GreaterThan="5"
-                                            TrueValue="Visible" />
+        <converters:DoubleToVisibilityConverter x:Key="DoubleToVisibilityConverter"
+                                                GreaterThan="5" />
     </Page.Resources>
 
     <Grid Width="64"
@@ -23,6 +21,6 @@
           BorderThickness="1">
         <Image HorizontalAlignment="Left"
                Source="/Assets/Converters.png"
-               Visibility="{x:Bind NumericValue, Mode=OneWay, Converter={StaticResource DoubleToVisibilityConverter}}" />
+               Visibility="{x:Bind NumericValue, Mode=OneWay, Converter={StaticResource DoubleToVisibilityConverter}, ConverterParameter=True}" />
     </Grid>
 </Page>

--- a/components/Converters/samples/DoubleToVisibilityConverterSample.xaml.cs
+++ b/components/Converters/samples/DoubleToVisibilityConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleNumericOption("NumericValue", 0, 0, 10, 1, false, Title = "Number")]
+
+[ToolkitSample(id: nameof(DoubleToVisibilityConverterSample), "DoubleToVisibilityConverter", description: $"A sample for showing how to use the DoubleToObjectConverter.")]
+public sealed partial class DoubleToVisibilityConverterSample : Page
+{
+    public DoubleToVisibilityConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/EmptyStringToObjectConverterSample.xaml
+++ b/components/Converters/samples/EmptyStringToObjectConverterSample.xaml
@@ -1,0 +1,23 @@
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="ConvertersExperiment.Samples.EmptyStringToObjectConverterSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ConvertersExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:EmptyStringToObjectConverter x:Key="EmptyStringToObjectConverter"
+                                                 EmptyValue="False"
+                                                 NotEmptyValue="True" />
+    </Page.Resources>
+
+    <StackPanel>
+        <Button Content="Submit"
+                IsEnabled="{x:Bind MyTextStringValue, Mode=OneWay, Converter={StaticResource EmptyStringToObjectConverter}}"
+                Style="{StaticResource AccentButtonStyle}" />
+    </StackPanel>
+
+</Page>

--- a/components/Converters/samples/EmptyStringToObjectConverterSample.xaml.cs
+++ b/components/Converters/samples/EmptyStringToObjectConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleTextOption("MyTextStringValue", "", Title = "Enter text to enable the button")]
+
+[ToolkitSample(id: nameof(EmptyStringToObjectConverterSample), "EmptyStringToObjectConverter", description: $"A sample for showing how to use the EmptyStringToObjectConverter.")]
+public sealed partial class EmptyStringToObjectConverterSample : Page
+{
+    public EmptyStringToObjectConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/FileSizeToFriendlyStringConverterSample.xaml
+++ b/components/Converters/samples/FileSizeToFriendlyStringConverterSample.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ConvertersExperiment.Samples.CollectionVisibilityConverterSample"
+<Page x:Class="ConvertersExperiment.Samples.FileSizeToFriendlyStringConverterSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:converters="using:CommunityToolkit.WinUI.Converters"
@@ -9,18 +9,22 @@
       mc:Ignorable="d">
 
     <Page.Resources>
-        <converters:CollectionVisibilityConverter x:Key="CollectionVisibilityConverter" />
+        <converters:FileSizeToFriendlyStringConverter x:Key="FileSizeToFriendlyStringConverter" />
     </Page.Resources>
+    <StackPanel Orientation="Vertical"
+                Spacing="12">
 
-    <Grid>
-        <TextBlock HorizontalAlignment="Center"
-                   TextAlignment="Center"
-                   Visibility="{x:Bind EmptyCollection, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}, ConverterParameter=True}">
+
+        <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}">
+            <Run Text="Original value (Bytes):" />
             <Run FontWeight="SemiBold"
-                 Text="All done for the day" />
-            <LineBreak />
-            <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                 Text="Enjoy your empty inbox" />
+                 Text="{x:Bind FileSizeInBytes}" />
         </TextBlock>
-    </Grid>
+
+        <TextBlock>
+            <Run Text="Converted string:" />
+            <Run FontWeight="SemiBold"
+                 Text="{x:Bind FileSizeInBytes, Converter={StaticResource FileSizeToFriendlyStringConverter}}" />
+        </TextBlock>
+    </StackPanel>
 </Page>

--- a/components/Converters/samples/FileSizeToFriendlyStringConverterSample.xaml.cs
+++ b/components/Converters/samples/FileSizeToFriendlyStringConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSample(id: nameof(FileSizeToFriendlyStringConverterSample), "FileSizeToFriendlyStringConverter", description: $"A sample for showing how to use the FileSizeToFriendlyStringConverter.")]
+public sealed partial class FileSizeToFriendlyStringConverterSample : Page
+{
+    public long FileSizeInBytes = 2400000;
+
+    public FileSizeToFriendlyStringConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/StringFormatConverterSample.xaml.cs
+++ b/components/Converters/samples/StringFormatConverterSample.xaml.cs
@@ -9,8 +9,8 @@ namespace ConvertersExperiment.Samples;
 /// <summary>
 /// An example sample page of a custom control inheriting from Panel.
 /// </summary>
-[ToolkitSampleBoolOption("MyBooleanValue", true, Title = "Is Loading?")]
-[ToolkitSampleNumericOption("MyDoubleValue", step:0.25, Title = "Display Value")]
+[ToolkitSampleBoolOption("MyBooleanValue", true, Title = "Is loading")]
+[ToolkitSampleNumericOption("MyDoubleValue", 1, 0, 10, 0.25, false, Title = "Number of pixels")]
 [ToolkitSample(id: nameof(StringFormatConverterSample), "StringFormatConverter", description: $"A sample for showing how to use the StringFormatConverter.")]
 public sealed partial class StringFormatConverterSample : Page
 {

--- a/components/Converters/samples/StringVisibilityConverterSample.xaml
+++ b/components/Converters/samples/StringVisibilityConverterSample.xaml
@@ -9,13 +9,11 @@
       mc:Ignorable="d">
 
     <Page.Resources>
-        <converters:StringVisibilityConverter x:Key="StringVisibilityConverter"
-                                              EmptyValue="Visible"
-                                              NotEmptyValue="Collapsed" />
+        <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
     </Page.Resources>
 
     <TextBlock Text="This text is visible when the input TextBox is empty"
-               Visibility="{x:Bind MyTextStringValue, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}}" />
+               Visibility="{x:Bind MyTextStringValue, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}, ConverterParameter=True}" />
 
 
 </Page>

--- a/components/Converters/samples/StringVisibilityConverterSample.xaml
+++ b/components/Converters/samples/StringVisibilityConverterSample.xaml
@@ -1,0 +1,21 @@
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="ConvertersExperiment.Samples.StringVisibilityConverterSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:ConvertersExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:StringVisibilityConverter x:Key="StringVisibilityConverter"
+                                              EmptyValue="Visible"
+                                              NotEmptyValue="Collapsed" />
+    </Page.Resources>
+
+    <TextBlock Text="This text is visible when the input TextBox is empty"
+               Visibility="{x:Bind MyTextStringValue, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}}" />
+
+
+</Page>

--- a/components/Converters/samples/StringVisibilityConverterSample.xaml.cs
+++ b/components/Converters/samples/StringVisibilityConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleTextOption("MyTextStringValue", "", Title = "Enter text to hide the TextBlock")]
+
+[ToolkitSample(id: nameof(StringVisibilityConverterSample), "StringVisibilityConverter", description: $"A sample for showing how to use the StringVisibilityConverter.")]
+public sealed partial class StringVisibilityConverterSample : Page
+{
+    public StringVisibilityConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/TypeToObjectConverterSample.xaml
+++ b/components/Converters/samples/TypeToObjectConverterSample.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ConvertersExperiment.Samples.StringFormatConverterSample"
+<Page x:Class="ConvertersExperiment.Samples.TypeToObjectConverterSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:converters="using:CommunityToolkit.WinUI.Converters"
@@ -9,12 +9,14 @@
       mc:Ignorable="d">
 
     <Page.Resources>
-        <converters:StringFormatConverter x:Key="StringFormatConverter" />
+        <converters:TypeToObjectConverter x:Key="TypeToObjectConverter"
+                                          FalseValue="Red"
+                                          TrueValue="Green"
+                                          Type="x:String" />
     </Page.Resources>
 
-    <StackPanel Spacing="16">
-        <TextBlock Text="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='The page is loading: {0}'}" />
+    <TextBlock Foreground="{x:Bind MyTextStringValue, Mode=OneWay, Converter={StaticResource TypeToObjectConverter}}"
+               Text="This text is visible when the input TextBox is empty" />
 
-        <TextBlock Text="{x:Bind MyDoubleValue, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}There are {0:0.##} pixels'}" />
-    </StackPanel>
+
 </Page>

--- a/components/Converters/samples/TypeToObjectConverterSample.xaml
+++ b/components/Converters/samples/TypeToObjectConverterSample.xaml
@@ -15,8 +15,19 @@
                                           Type="x:String" />
     </Page.Resources>
 
-    <TextBlock Foreground="{x:Bind MyTextStringValue, Mode=OneWay, Converter={StaticResource TypeToObjectConverter}}"
-               Text="This text is visible when the input TextBox is empty" />
+    <StackPanel Spacing="8">
+        <ComboBox x:Name="Selection"
+                  SelectedIndex="0">
+            <ComboBoxItem>
+                <x:Int32>64</x:Int32>
+            </ComboBoxItem>
+            <ComboBoxItem>
+                <x:Double>44.44</x:Double>
+            </ComboBoxItem>
+            <ComboBoxItem>I'm a String!</ComboBoxItem>
+        </ComboBox>
 
-
+        <TextBlock Foreground="{x:Bind ((ComboBoxItem)Selection.SelectedItem).Content, Mode=OneWay, Converter={StaticResource TypeToObjectConverter}}"
+                   Text="This text is Green when a string is selected" />
+    </StackPanel>
 </Page>

--- a/components/Converters/samples/TypeToObjectConverterSample.xaml.cs
+++ b/components/Converters/samples/TypeToObjectConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleTextOption("MyTextStringValue", "", Title = "Enter text to hide the TextBlock")]
+
+[ToolkitSample(id: nameof(TypeToObjectConverterSample), "TypeToObjectConverter", description: $"A sample for showing how to use the TypeToObjectConverter.")]
+public sealed partial class TypeToObjectConverterSample : Page
+{
+    public TypeToObjectConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/samples/TypeToObjectConverterSample.xaml.cs
+++ b/components/Converters/samples/TypeToObjectConverterSample.xaml.cs
@@ -4,8 +4,6 @@
 
 namespace ConvertersExperiment.Samples;
 
-[ToolkitSampleTextOption("MyTextStringValue", "", Title = "Enter text to hide the TextBlock")]
-
 [ToolkitSample(id: nameof(TypeToObjectConverterSample), "TypeToObjectConverter", description: $"A sample for showing how to use the TypeToObjectConverter.")]
 public sealed partial class TypeToObjectConverterSample : Page
 {

--- a/components/Converters/samples/VisibilityToBoolConverterSample.xaml
+++ b/components/Converters/samples/VisibilityToBoolConverterSample.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ConvertersExperiment.Samples.BoolToVisibilityConverterSample"
+<Page x:Class="ConvertersExperiment.Samples.VisibilityToBoolConverterSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:converters="using:CommunityToolkit.WinUI.Converters"
@@ -19,22 +19,21 @@
             </Style.Setters>
         </Style>
 
-        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <converters:VisibilityToBoolConverter x:Key="VisibilityToBoolConverter" />
     </Page.Resources>
 
-    <StackPanel Orientation="Horizontal"
-                Spacing="12">
+    <StackPanel Spacing="12">
         <Border Style="{StaticResource PlaceholderCardStyle}">
-            <Image HorizontalAlignment="Left"
+            <Image x:Name="image"
+                   HorizontalAlignment="Left"
                    Source="/Assets/Converters.png"
-                   Visibility="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                   Visibility="{x:Bind MyBooleanValue, Mode=OneWay}" />
         </Border>
-
-        <Border Style="{StaticResource PlaceholderCardStyle}">
-            <Image HorizontalAlignment="Left"
-                   Source="/Assets/Converters.png"
-                   Visibility="{x:Bind MyBooleanValue, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=True}" />
-        </Border>
+        <TextBlock>
+            <Run Text="Image visibility:" />
+            <Run FontWeight="SemiBold"
+                 Text="{Binding ElementName=image, Path=Visibility, Mode=OneWay, Converter={StaticResource VisibilityToBoolConverter}}" />
+        </TextBlock>
     </StackPanel>
 
 </Page>

--- a/components/Converters/samples/VisibilityToBoolConverterSample.xaml.cs
+++ b/components/Converters/samples/VisibilityToBoolConverterSample.xaml.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ConvertersExperiment.Samples;
+
+[ToolkitSampleBoolOption("MyBooleanValue", true, Title = "Toggle to show or hide the image")]
+
+[ToolkitSample(id: nameof(VisibilityToBoolConverterSample), "VisibilityToBoolConverter", description: $"A sample for showing how to use the VisibilityToBoolConverter.")]
+public sealed partial class VisibilityToBoolConverterSample : Page
+{
+    public VisibilityToBoolConverterSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Converters/src/ColorToDisplayNameConverter.cs
+++ b/components/Converters/src/ColorToDisplayNameConverter.cs
@@ -37,7 +37,8 @@ public class ColorToDisplayNameConverter : IValueConverter
 #if !WINAPPSDK && !HAS_UNO
         return Windows.UI.ColorHelper.ToDisplayName(color);
 #else
-        throw new NotSupportedException("See https://github.com/microsoft/microsoft-ui-xaml/issues/8287");
+        // ToDisplayName not yet supported on WASDK. See https://github.com/microsoft/microsoft-ui-xaml/issues/8287
+        return "Not supported";
 #endif
     }
 


### PR DESCRIPTION
- Adding a few new samples for various converters. (No sample for e.g. TaskResultConverter and ResourceStringConverter as these might not be used that much?) Maybe a code 1 liner is enough?

Known issues:
- The EmptyCollection converter sample does not seem to work.. Converter doesn't get triggered when the collection changes?
- ColorToDisplayName sample not working for WASDK

@michael-hawker Would love to get your feedback on these samples - wanted to keep them as simple as possible to let devs quickly copy-and-paste what they need vs. complex use cases - especially since Converters are pretty straightforward to work with? 