### PR TITLE
Add Converters property to directory props to build converters from source for sample app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ env:
   ENABLE_DIAGNOSTICS: false
   #COREHOST_TRACE: 1
   COREHOST_TRACEFILE: corehosttrace.log
+  MULTI_TARGET_DIRECTORY: tooling/MultiTarget
+  HEADS_DIRECTORY: tooling/ProjectHeads
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -60,7 +62,6 @@ jobs:
         platform: [WinUI2, WinUI3]
 
     env:
-      MULTI_TARGET_DIRECTORY: tooling/MultiTarget
       # faux-ternary expression to select which platforms to build for each platform vs. duplicating step below.
       TARGET_PLATFORMS: ${{ matrix.platform != 'WinUI3' && 'all' || 'all-uwp' }}
       TEST_PLATFORM: ${{ matrix.platform != 'WinUI3' && 'UWP' || 'WinAppSdk' }}
@@ -153,8 +154,6 @@ jobs:
 
   wasm-linux:
     runs-on: ubuntu-latest
-    env:
-      HEADS_DIRECTORY: tooling/ProjectHeads
 
     steps:
       - name: Install .NET SDK v${{ env.DOTNET_VERSION }}
@@ -175,6 +174,11 @@ jobs:
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools
         run: dotnet tool restore
+
+      - name: Enable WASM TargetFrameworks
+        shell: pwsh
+        working-directory: ./${{ env.MULTI_TARGET_DIRECTORY }}
+        run: ./UseTargetFrameworks.ps1 wasm
 
       - name: Generate solution
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
       # See launch.json configuration file for analogous command we're emulating here to build LINK: ../../.vscode/launch.json:CommunityToolkit.App.Wasm.csproj
       - name: dotnet build
         working-directory: ./${{ env.HEADS_DIRECTORY }}/AllComponents/Wasm/
-        run: dotnet build /r /bl /p:UnoSourceGeneratorUseGenerationHost=true /p:UnoSourceGeneratorUseGenerationController=false
+        run: dotnet build /r /bl
   
       # TODO: Do we want to run tests here? Can we do that on linux easily?
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,6 @@
         "build",
         "/r",
         "/bl",
-        "/p:UnoSourceGeneratorUseGenerationHost=true",
-        "/p:UnoSourceGeneratorUseGenerationController=false",
         "/p:UnoRemoteControlPort=443",
         "--project=${workspaceFolder}/tooling/ProjectHeads/AllComponents/Wasm/CommunityToolkit.App.Wasm.csproj"
       ],

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,9 @@
     <ToolingDirectory>$(RepositoryDirectory)\tooling</ToolingDirectory>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <ToolkitExtensionSourceProject>$(RepositoryDirectory)\components\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj</ToolkitExtensionSourceProject>
+    <ToolkitConvertersSourceProject>$(RepositoryDirectory)\components\Converters\src\CommunityToolkit.WinUI.Converters.csproj</ToolkitConvertersSourceProject>
+
+    <!-- TODO: See https://github.com/CommunityToolkit/Windows/issues/117 these should be removed unless needed by sample app or tests -->
     <ToolkitHelperSourceProject>$(RepositoryDirectory)\components\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj</ToolkitHelperSourceProject>
     <ToolkitBehaviorSourceProject>$(RepositoryDirectory)\components\Behaviors\src\CommunityToolkit.WinUI.Behaviors.csproj</ToolkitBehaviorSourceProject>
     <ToolkitAnimationSourceProject>$(RepositoryDirectory)\components\Animations\src\CommunityToolkit.WinUI.Animations.csproj</ToolkitAnimationSourceProject>


### PR DESCRIPTION
Separating out from #138 

Follow-on from https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/99

138 isn't building in linux for some reason related to converters, but everything works fine locally. Figured would try splitting this out first to see if that changes anything.