### PR TITLE
Bumped SettingsControl version number, enable other TFMs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,6 @@
     "csharp.suppressDotnetInstallWarning": true,
     "csharp.suppressDotnetRestoreNotification": true,
     "csharp.semanticHighlighting.enabled": true,
-    "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
-    "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
-    "dotnet.defaultSolution": "tooling/CommunityToolkit.Tooling.sln"
+    "omnisharp.enableImportCompletion": true,
+    "omnisharp.enableMsBuildLoadProjectsOnDemand": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "csharp.suppressDotnetInstallWarning": true,
     "csharp.suppressDotnetRestoreNotification": true,
     "csharp.semanticHighlighting.enabled": true,
-    "omnisharp.enableImportCompletion": true,
-    "omnisharp.enableMsBuildLoadProjectsOnDemand": true
+    "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+    "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+    "dotnet.defaultSolution": "tooling/CommunityToolkit.Tooling.sln"
 }

--- a/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
+++ b/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ToolkitComponentName>SettingsControls</ToolkitComponentName>
     <Description>This package contains SettingsControls.</Description>
-    <Version>8.0.0-beta.1</Version>
+    <Version>8.0.0-beta.2</Version>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.SettingsControlsRns</RootNamespace>
@@ -11,7 +11,7 @@
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
-<ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\Triggers\src\CommunityToolkit.WinUI.Triggers.csproj"></ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
This PR is a hotfix for SettingsControl. The most recent version `8.0.0-beta.1` seems to only have uwp, wasdk and wasm enabled. 

Building a nuget package locally, the missing TFMs were available. Bumping the version will allow us to push a new package, enabling the missing TFMs.