### PR TITLE
Upgrade to .NET 7, enable WASM optimizations

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "uno.check": {
-      "version": "1.10.0",
+      "version": "1.13.0",
       "commands": [
         "uno-check"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -435,3 +435,6 @@ dotnet_diagnostic.IDE0073.severity = warning
 
 # Uno platform exposes IDisposable on Storyboard publicly when it should be internal. Ignore this.
 dotnet_code_quality.CA1001.excluded_type_names_with_derived_types = T:Windows.UI.Xaml.Media.Animation.Storyboard
+
+# XML comment has cref attribute that could not be resolved (temp, remove XML generated docs get used)
+dotnet_diagnostic.CS1574.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -435,6 +435,3 @@ dotnet_diagnostic.IDE0073.severity = warning
 
 # Uno platform exposes IDisposable on Storyboard publicly when it should be internal. Ignore this.
 dotnet_code_quality.CA1001.excluded_type_names_with_derived_types = T:Windows.UI.Xaml.Media.Animation.Storyboard
-
-# XML comment has cref attribute that could not be resolved (temp, remove XML generated docs get used)
-dotnet_diagnostic.CS1587.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -437,5 +437,4 @@ dotnet_diagnostic.IDE0073.severity = warning
 dotnet_code_quality.CA1001.excluded_type_names_with_derived_types = T:Windows.UI.Xaml.Media.Animation.Storyboard
 
 # XML comment has cref attribute that could not be resolved (temp, remove XML generated docs get used)
-dotnet_diagnostic.CS1574.severity = none
 dotnet_diagnostic.CS1587.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -438,3 +438,4 @@ dotnet_code_quality.CA1001.excluded_type_names_with_derived_types = T:Windows.UI
 
 # XML comment has cref attribute that could not be resolved (temp, remove XML generated docs get used)
 dotnet_diagnostic.CS1574.severity = none
+dotnet_diagnostic.CS1587.severity = none

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
   merge_group:
 
 env:
-  DOTNET_VERSION: ${{ '7.0.x' }}
+  DOTNET_VERSION: ${{ '7.0.100' }}
   ENABLE_DIAGNOSTICS: true
   MSBUILD_VERBOSITY: normal
   #COREHOST_TRACE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
       # faux-ternary expression to select which platforms to build for each platform vs. duplicating step below.
       TARGET_PLATFORMS: ${{ matrix.platform != 'WinUI3' && 'all' || 'all-uwp' }}
       TEST_PLATFORM: ${{ matrix.platform != 'WinUI3' && 'UWP' || 'WinAppSdk' }}
+      VERSION_PROPERTY: ${{ github.ref == 'refs/heads/main' && format('-p:PreviewVersion=build.{0}', github.run_number) || format('-p:PreviewVersion=pull-{0}.{1}', github.event.number, github.run_number) }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -124,12 +125,12 @@ jobs:
         if: ${{ matrix.platform == 'WinUI3' }}
 
       - name: MSBuild
-        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release -m ${{ github.ref == 'refs/heads/main' && '' || format('-p:PreviewVersion="pull-{0}+build.{1}"', github.event.number, github.run_number) }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '/bl' || '' }} -v:${{ env.MSBUILD_VERBOSITY }}
+        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release -m ${{ env.VERSION_PROPERTY }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '/bl' || '' }} -v:${{ env.MSBUILD_VERBOSITY }}
 
       # Build All Packages
       - name: pack experiments
         working-directory: ./tooling/Scripts/
-        run: ./PackEachExperiment.ps1 all
+        run: ./PackEachExperiment.ps1 -extraBuildProperties "${{ env.VERSION_PROPERTY }}"
 
       # Push Packages to our DevOps Artifacts Feed (see nuget.config)
       - name: Add source (main)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Run Uno Check to Install Dependencies
-        run: dotnet tool run uno-check --ci --fix --non-interactive --skip wsl --skip androidemulator --verbose
+        run: dotnet tool run uno-check --ci --fix --non-interactive --skip wsl --skip androidemulator --skip vswinworkloads --verbose
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ on:
 env:
   DOTNET_VERSION: ${{ '7.0.x' }}
   ENABLE_DIAGNOSTICS: true
+  MSBUILD_VERBOSITY: normal
   #COREHOST_TRACE: 1
   COREHOST_TRACEFILE: corehosttrace.log
   MULTI_TARGET_DIRECTORY: tooling/MultiTarget
@@ -122,13 +123,8 @@ jobs:
         run: powershell -version 5.1 -command "./UseUnoWinUI.ps1 3" -ErrorAction Stop
         if: ${{ matrix.platform == 'WinUI3' }}
 
-      - name: MSBuild (With diagnostics)
-        if: ${{ env.ENABLE_DIAGNOSTICS == 'true' }}
-        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release -m /bl -v:diag
-
       - name: MSBuild
-        if: ${{ env.ENABLE_DIAGNOSTICS == 'false' }}
-        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release -m
+        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release -m ${{ github.ref == 'refs/heads/main' && '' || format('-p:PreviewVersion="pull-{0}+build.{1}"', github.event.number, github.run_number) }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '/bl' || '' }} -v:${{ env.MSBUILD_VERBOSITY }}
 
       # Build All Packages
       - name: pack experiments
@@ -136,13 +132,16 @@ jobs:
         run: ./PackEachExperiment.ps1 all
 
       # Push Packages to our DevOps Artifacts Feed (see nuget.config)
-      - name: Add source
+      - name: Add source (main)
         if: ${{ github.ref == 'refs/heads/main' }}
         run: dotnet nuget update source MainLatest --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
 
+      - name: Add source (pull requests)
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: dotnet nuget add source https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-PullRequests/nuget/v3/index.json --name PullRequests --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
+
       - name: Push packages
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: dotnet nuget push "**/*.nupkg" --api-key dummy --source MainLatest --skip-duplicate
+        run: dotnet nuget push "**/*.nupkg" --api-key dummy --source ${{ github.ref == 'refs/heads/main' && 'MainLatest' || 'PullRequests' }} --skip-duplicate
 
       # Run tests
       - name: Setup VSTest Path
@@ -241,7 +240,7 @@ jobs:
       # See launch.json configuration file for analogous command we're emulating here to build LINK: ../../.vscode/launch.json:CommunityToolkit.App.Wasm.csproj
       - name: dotnet build
         working-directory: ./${{ env.HEADS_DIRECTORY }}/AllComponents/Wasm/
-        run: dotnet build /r /bl
+        run: dotnet build /r /bl -v:${{ env.MSBUILD_VERBOSITY }}
   
       # TODO: Do we want to run tests here? Can we do that on linux easily?
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PreviewVersion>preview</PreviewVersion>
+    <PreviewVersion Condition="'$(PreviewVersion)' == ''">preview</PreviewVersion>
 
     <PackageIdPrefix>CommunityToolkit</PackageIdPrefix>
     <RepositoryDirectory>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepositoryDirectory>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PreviewVersion Condition="'$(PreviewVersion)' == ''">preview</PreviewVersion>
+    <PreviewVersion>preview</PreviewVersion>
 
     <PackageIdPrefix>CommunityToolkit</PackageIdPrefix>
     <RepositoryDirectory>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepositoryDirectory>

--- a/components/Animations/src/ConnectedAnimations/Connected.cs
+++ b/components/Animations/src/ConnectedAnimations/Connected.cs
@@ -53,7 +53,7 @@ public static class Connected
     /// <summary>
     /// Gets the connected animation key associated with the ListViewBase item being animated
     /// </summary>
-    /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.ListViewBase"/></param>
+    /// <param name="obj">The <see cref="ListViewBase"/></param>
     /// <returns>The connected animation key</returns>
     public static string GetListItemKey(DependencyObject obj)
     {
@@ -61,9 +61,9 @@ public static class Connected
     }
 
     /// <summary>
-    /// Sets the connected animation key for the <see cref="Windows.UI.Xaml.Controls.ListViewBase"/> item being animated
+    /// Sets the connected animation key for the <see cref="ListViewBase"/> item being animated
     /// </summary>
-    /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.ListViewBase"/></param>
+    /// <param name="obj">The <see cref="ListViewBase"/></param>
     /// <param name="value">The connected animation key</param>
     public static void SetListItemKey(DependencyObject obj, string value)
     {
@@ -73,7 +73,7 @@ public static class Connected
     /// <summary>
     /// Gets the name of the element in the <see cref="DataTemplate"/> that is animated
     /// </summary>
-    /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.ListViewBase"/></param>
+    /// <param name="obj">The <see cref="ListViewBase"/></param>
     /// <returns>The name of the element being animated</returns>
     public static string GetListItemElementName(DependencyObject obj)
     {
@@ -83,7 +83,7 @@ public static class Connected
     /// <summary>
     /// Sets the name of the element in the <see cref="DataTemplate"/> that is animated
     /// </summary>
-    /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.ListViewBase"/></param>
+    /// <param name="obj">The <see cref="ListViewBase"/></param>
     /// <param name="value">The name of the element to animate</param>
     public static void SetListItemElementName(DependencyObject obj, string value)
     {

--- a/components/Animations/src/Enums/FrameworkLayer.cs
+++ b/components/Animations/src/Enums/FrameworkLayer.cs
@@ -10,12 +10,20 @@ namespace CommunityToolkit.WinUI.Animations;
 public enum FrameworkLayer
 {
     /// <summary>
+#if WINUI2
     /// Indicates the <see cref="Windows.UI.Composition"/> APIs.
+#elif WINUI3
+    /// Indicates the <see cref="Microsoft.UI.Composition"/> APIs.
+#endif
     /// </summary>
     Composition,
-
+    
     /// <summary>
+#if WINUI2
     /// Indicates the <see cref="Windows.UI.Xaml.Media.Animation"/> APIs.
+#elif WINUI3
+    /// Indicates the <see cref="Microsoft.UI.Xaml.Media.Animation"/> APIs.
+#endif
     /// </summary>
     Xaml
 }

--- a/components/Animations/src/Enums/FrameworkLayer.cs
+++ b/components/Animations/src/Enums/FrameworkLayer.cs
@@ -2,6 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if WINUI2
+using Composition = Windows.UI.Composition;
+using Animation = Windows.UI.Xaml.Media.Animation;
+#elif WINUI3
+using Composition = Microsoft.UI.Composition;
+using Animation = Microsoft.UI.Xaml.Media.Animation;
+#endif
+
 namespace CommunityToolkit.WinUI.Animations;
 
 /// <summary>
@@ -10,20 +18,12 @@ namespace CommunityToolkit.WinUI.Animations;
 public enum FrameworkLayer
 {
     /// <summary>
-#if WINUI2
-    /// Indicates the <see cref="Windows.UI.Composition"/> APIs.
-#elif WINUI3
-    /// Indicates the <see cref="Microsoft.UI.Composition"/> APIs.
-#endif
+    /// Indicates the <see cref="Composition"/> APIs.
     /// </summary>
     Composition,
     
     /// <summary>
-#if WINUI2
-    /// Indicates the <see cref="Windows.UI.Xaml.Media.Animation"/> APIs.
-#elif WINUI3
-    /// Indicates the <see cref="Microsoft.UI.Xaml.Media.Animation"/> APIs.
-#endif
+    /// Indicates the <see cref="Animation"/> APIs.
     /// </summary>
     Xaml
 }

--- a/components/Animations/src/Enums/VisualProperty.cs
+++ b/components/Animations/src/Enums/VisualProperty.cs
@@ -4,6 +4,12 @@
 
 namespace CommunityToolkit.WinUI.Animations;
 
+#if WINUI2
+using Windows.UI.Composition;
+#else
+using Microsoft.UI.Composition;
+#endif
+
 /// <summary>
 /// Indicates a property of a <see cref="Visual"/> object.
 /// </summary>

--- a/components/Animations/src/Expressions/ReferenceNodes/AmbientLightReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/AmbientLightReferenceNode.cs
@@ -13,7 +13,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// <summary>
 /// Class AmbientLightReferenceNode. This class cannot be inherited.
 /// </summary>
-/// <seealso cref="Microsoft.Toolkit.Uwp.UI.Animations.Expressions.ReferenceNode" />
+/// <seealso cref="ReferenceNode" />
 public sealed class AmbientLightReferenceNode : ReferenceNode
 {
     /// <summary>

--- a/components/Animations/src/Xaml/Abstract/CustomAnimation{TValue,TKeyFrame}.cs
+++ b/components/Animations/src/Xaml/Abstract/CustomAnimation{TValue,TKeyFrame}.cs
@@ -19,6 +19,9 @@ public abstract class CustomAnimation<TValue, TKeyFrame> : ImplicitAnimation<TVa
     /// </summary>
     public string? Target { get; set; }
 
+
+// Suppression required for net7-android. The #if compilation conditionals are preventing the compiler from interpreting it correctly.
+#pragma warning disable CS1587 // XML comment is not placed on a valid language element
     /// <summary>
     /// Gets or sets the target framework layer for the animation. This is only supported
     /// for a set of animation types (see the docs for more on this). Furthermore, this is
@@ -31,6 +34,7 @@ public abstract class CustomAnimation<TValue, TKeyFrame> : ImplicitAnimation<TVa
     /// The default value is <see cref="FrameworkLayer.Xaml"/>.
     /// </summary>
     public FrameworkLayer Layer { get; set; } = FrameworkLayer.Xaml;
+#pragma warning restore CS1587 // XML comment is not placed on a valid language element
 #endif
 
     /// <inheritdoc/>

--- a/components/Animations/src/Xaml/AnimationSet.cs
+++ b/components/Animations/src/Xaml/AnimationSet.cs
@@ -5,11 +5,17 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
+#if WINUI2
+using Windows.UI.Xaml.Media.Animation;
+#else
+using Microsoft.UI.Xaml.Media.Animation;
+#endif
+
 namespace CommunityToolkit.WinUI.Animations;
 
 /// <summary>
 /// A collection of animations that can be grouped together. This type represents a composite animation
-/// (such as <see cref="Windows.UI.Xaml.Media.Animation.Storyboard"/>) that can be executed on a given element.
+/// (such as <see cref="Storyboard"/>) that can be executed on a given element.
 /// </summary>
 public sealed class AnimationSet : DependencyObjectCollection
 {

--- a/components/Behaviors/src/Notification/StackedNotificationsBehavior.cs
+++ b/components/Behaviors/src/Notification/StackedNotificationsBehavior.cs
@@ -13,7 +13,7 @@ using DQ = Microsoft.UI.Dispatching.DispatcherQueue;
 namespace CommunityToolkit.WinUI.Behaviors;
 
 /// <summary>
-/// A behavior to add the stacked notification support to <see cref="InfoBar"/>.
+/// A behavior to add the stacked notification support to <see cref="MUXC.InfoBar"/>.
 /// </summary>
 public class StackedNotificationsBehavior : BehaviorBase<MUXC.InfoBar>
 {

--- a/components/Collections/samples/AdvancedCollectionViewSample.xaml.cs
+++ b/components/Collections/samples/AdvancedCollectionViewSample.xaml.cs
@@ -61,7 +61,7 @@ public sealed partial class AdvancedCollectionViewSample : Page
     }
 
     /// <summary>
-    /// A sample class used to show how to use the <see cref="Collections.IIncrementalSource{TSource}"/> interface.
+    /// A sample class used to show how to use the <see cref="IIncrementalSource{TSource}"/> interface.
     /// </summary>
     public class Person
     {

--- a/components/Collections/samples/IncrementalLoadingCollectionSample.xaml.cs
+++ b/components/Collections/samples/IncrementalLoadingCollectionSample.xaml.cs
@@ -32,9 +32,9 @@ public sealed partial class IncrementalLoadingCollectionSample : Page
 }
 
 /// <summary>
-/// A sample implementation of the <see cref="Collections.IIncrementalSource{TSource}"/> interface.
+/// A sample implementation of the <see cref="IIncrementalSource{TSource}"/> interface.
 /// </summary>
-/// <seealso cref="Collections.IIncrementalSource{TSource}"/>
+/// <seealso cref="IIncrementalSource{TSource}"/>
 public class PeopleSource : IIncrementalSource<Person>
 {
     private readonly List<Person> _people;
@@ -92,7 +92,7 @@ public class PeopleSource : IIncrementalSource<Person>
 }
 
 /// <summary>
-/// A sample class used to show how to use the <see cref="Collections.IIncrementalSource{TSource}"/> interface.
+/// A sample class used to show how to use the <see cref="IIncrementalSource{TSource}"/> interface.
 /// </summary>
 public class Person
 {

--- a/components/Converters/src/FileSizeToFriendlyStringConverter.cs
+++ b/components/Converters/src/FileSizeToFriendlyStringConverter.cs
@@ -5,7 +5,7 @@
 namespace CommunityToolkit.WinUI.Converters;
 
 /// <summary>
-/// Converts a file size in bytes to a more human-readable friendly format using <see cref="Toolkit.Converters.ToFileSizeString(long)"/>
+/// Converts a file size in bytes to a more human-readable friendly format using <see cref="Converters.ToFileSizeString(long)"/>
 /// </summary>
 public class FileSizeToFriendlyStringConverter : IValueConverter
 {

--- a/components/Converters/src/FileSizeToFriendlyStringConverter.cs
+++ b/components/Converters/src/FileSizeToFriendlyStringConverter.cs
@@ -5,7 +5,7 @@
 namespace CommunityToolkit.WinUI.Converters;
 
 /// <summary>
-/// Converts a file size in bytes to a more human-readable friendly format using <see cref="Converters.ToFileSizeString(long)"/>
+/// Converts a file size in bytes to a more human-readable friendly format using <see cref="CommunityToolkit.Common.Converters.ToFileSizeString(long)"/>
 /// </summary>
 public class FileSizeToFriendlyStringConverter : IValueConverter
 {

--- a/components/Extensions/src/Element/FrameworkElementExtensions.ActualSize.cs
+++ b/components/Extensions/src/Element/FrameworkElementExtensions.ActualSize.cs
@@ -5,12 +5,12 @@
 namespace CommunityToolkit.WinUI;
 
 /// <summary>
-/// Provides attached dependency properties for the <see cref="Microsoft.UI.Xaml.FrameworkElement"/> type.
+/// Provides attached dependency properties for the <see cref="FrameworkElement"/> type.
 /// </summary>
 public static partial class FrameworkElementExtensions
 {
     /// <summary>
-    /// Attached <see cref="DependencyProperty"/> for enabling actual size binding on any  <see cref="Microsoft.UI.Xaml.FrameworkElement"/>.
+    /// Attached <see cref="DependencyProperty"/> for enabling actual size binding on any  <see cref="FrameworkElement"/>.
     /// </summary>
     public static readonly DependencyProperty EnableActualSizeBindingProperty = DependencyProperty.RegisterAttached("EnableActualSizeBinding", typeof(bool), typeof(FrameworkElementExtensions), new PropertyMetadata(false, OnEnableActualSizeBindingPropertyChanged));
 

--- a/components/Extensions/src/Element/FrameworkElementExtensions.Mouse.cs
+++ b/components/Extensions/src/Element/FrameworkElementExtensions.Mouse.cs
@@ -32,14 +32,14 @@ public static partial class FrameworkElementExtensions
         new() { { CursorShape.Arrow, _defaultCursor } };
 
     /// <summary>
-    /// Dependency property for specifying the target <see cref="InputSystemCursorShape"/> to be shown
+    /// Dependency property for specifying the target <see cref="CursorShape"/> to be shown
     /// over the target <see cref="FrameworkElement"/>.
     /// </summary>
     public static readonly DependencyProperty CursorProperty =
         DependencyProperty.RegisterAttached("Cursor", typeof(CursorShape), typeof(FrameworkElementExtensions), new PropertyMetadata(CursorShape.Arrow, CursorChanged));
 
     /// <summary>
-    /// Set the target <see cref="InputSystemCursorShape"/>.
+    /// Set the target <see cref="CursorShape"/>.
     /// </summary>
     /// <param name="element">Object where the selector cursor type should be shown.</param>
     /// <param name="value">Target cursor type value.</param>
@@ -49,7 +49,7 @@ public static partial class FrameworkElementExtensions
     }
 
     /// <summary>
-    /// Get the current <see cref="InputSystemCursorShape"/>.
+    /// Get the current <see cref="CursorShape"/>.
     /// </summary>
     /// <param name="element">Object where the selector cursor type should be shown.</param>
     /// <returns>Cursor type set on target element.</returns>

--- a/components/Extensions/src/Element/UIElementExtensions.cs
+++ b/components/Extensions/src/Element/UIElementExtensions.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml.Hosting;
 namespace CommunityToolkit.WinUI;
 
 /// <summary>
-/// Provides attached dependency properties for the <see cref="Microsoft.UI.Xaml.UIElement"/>
+/// Provides attached dependency properties for the <see cref="UIElement"/>
 /// </summary>
 public static class UIElementExtensions
 {

--- a/components/Extensions/src/Markup/SymbolIconExtension.cs
+++ b/components/Extensions/src/Markup/SymbolIconExtension.cs
@@ -11,7 +11,7 @@ namespace CommunityToolkit.WinUI;
 public class SymbolIconExtension : TextIconExtension
 {
     /// <summary>
-    /// Gets or sets the <see cref="Microsoft.UI.Xaml.Controls.Symbol"/> value representing the icon to display.
+    /// Gets or sets the <see cref="Symbol"/> value representing the icon to display.
     /// </summary>
     public Symbol Symbol { get; set; }
 

--- a/components/Extensions/src/Markup/SymbolIconSourceExtension.cs
+++ b/components/Extensions/src/Markup/SymbolIconSourceExtension.cs
@@ -11,7 +11,7 @@ namespace CommunityToolkit.WinUI;
 public class SymbolIconSourceExtension : TextIconExtension
 {
     /// <summary>
-    /// Gets or sets the <see cref="Microsoft.UI.Xaml.Controls.Symbol"/> value representing the icon to display.
+    /// Gets or sets the <see cref="Symbol"/> value representing the icon to display.
     /// </summary>
     public Symbol Symbol { get; set; }
 

--- a/components/Extensions/src/Shadows/AttachedShadowBase.cs
+++ b/components/Extensions/src/Shadows/AttachedShadowBase.cs
@@ -27,7 +27,7 @@ public abstract partial class AttachedShadowBase : DependencyObject, IAttachedSh
     /// <summary>
     /// Gets a value indicating whether or not Composition's VisualSurface is supported.
     /// </summary>
-    protected static readonly bool SupportsCompositionVisualSurface = ApiInformation.IsTypePresent(typeof(CompositionVisualSurface).FullName);
+    protected static readonly bool SupportsCompositionVisualSurface = typeof(CompositionVisualSurface).FullName is string str && ApiInformation.IsTypePresent(str);
 #endif
 
     /// <summary>

--- a/components/Extensions/src/Shadows/IAttachedShadow.cs
+++ b/components/Extensions/src/Shadows/IAttachedShadow.cs
@@ -22,7 +22,7 @@ public interface IAttachedShadow
     double Opacity { get; set; }
 
     /// <summary>
-    /// Gets or sets the offset of the shadow as a string representation of a <see cref="Vector3"/>.
+    /// Gets or sets the offset of the shadow as a string representation of a <see cref="System.Numerics.Vector3"/>.
     /// </summary>
     string Offset { get; set; }
 

--- a/components/Helpers/samples/CameraHelperSample.xaml.cs
+++ b/components/Helpers/samples/CameraHelperSample.xaml.cs
@@ -7,6 +7,7 @@ using Windows.Graphics.Imaging;
 using Windows.Media;
 using Windows.Media.Capture.Frames;
 using Windows.ApplicationModel;
+
 #if WINAPPSDK
 using Microsoft.UI.Xaml.Media.Imaging;
 #else
@@ -62,7 +63,7 @@ public sealed partial class CameraHelperSample : UserControl
 #endif
     }
 
-    private async void Application_Suspending(object sender, SuspendingEventArgs e)
+    private async void Application_Suspending(object? sender, SuspendingEventArgs e)
     {
         if (IsLoaded)
         {
@@ -72,7 +73,7 @@ public sealed partial class CameraHelperSample : UserControl
         }
     }
 
-    private async void Application_Resuming(object sender, object e)
+    private async void Application_Resuming(object? sender, object e)
     {
         await InitializeAsync();
     }

--- a/components/Primitives/src/WrapPanel/StretchChild.cs
+++ b/components/Primitives/src/WrapPanel/StretchChild.cs
@@ -5,7 +5,7 @@
 namespace CommunityToolkit.WinUI.Controls;
 
 /// <summary>
-/// Options for how to calculate the layout of <see cref="Microsoft.UI.Xaml.Controls.WrapGrid"/> items.
+/// Options for how to calculate the layout of <see cref="WrapGrid"/> items.
 /// </summary>
 public enum StretchChild
 {

--- a/components/Sizers/src/SizerBase.cs
+++ b/components/Sizers/src/SizerBase.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.WinUI.Controls.Automation.Peers;
 namespace CommunityToolkit.WinUI.Controls;
 
 /// <summary>
-/// Base class for splitting/resizing type controls like <see cref="GridSplitter"/> and <see cref="ContentSizer"/>. Acts similar to an enlarged <see cref="Windows.UI.Xaml.Controls.Primitives.Thumb"/> type control, but with keyboard support. Subclasses should override the various abstract methods here to implement their behavior.
+/// Base class for splitting/resizing type controls like <see cref="GridSplitter"/> and <see cref="ContentSizer"/>. Acts similar to an enlarged <see cref="Thumb"/> type control, but with keyboard support. Subclasses should override the various abstract methods here to implement their behavior.
 /// </summary>
 
 [TemplateVisualState(Name = NormalState, GroupName = CommonStates)]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.405",
+    "version": "7.0.306",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.306",
+    "version": "7.0.100",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 


### PR DESCRIPTION
Companion PR to https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/117, which should be closed before merging this.

As noted:
> Any codebase consuming the tooling repo will need to be adjusted to account for the new nullable annotations and analyzers added between netstandard2.0 and net7.0.

This PR pulls in the .NET 7 upgrade and fixes the new warnings and errors that appeared in our codebase as a result.