### PR TITLE
Add a Meta Package for Controls which contains all the controls available in the Toolkit

### DIFF
--- a/components/Controls/OpenSolution.bat
+++ b/components/Controls/OpenSolution.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+powershell ..\..\tooling\ProjectHeads\GenerateSingleSampleHeads.ps1 -componentPath %CD% %*

--- a/components/Controls/src/CommunityToolkit.WinUI.Controls.csproj
+++ b/components/Controls/src/CommunityToolkit.WinUI.Controls.csproj
@@ -5,10 +5,12 @@
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.ControlsRns</RootNamespace>
+    
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
   <!-- Sets this up as a toolkit component's source project -->
-  <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+  <!-- <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" /> -->
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)ReadMe.txt" Pack="true" PackagePath="\" />

--- a/components/Controls/src/CommunityToolkit.WinUI.Controls.csproj
+++ b/components/Controls/src/CommunityToolkit.WinUI.Controls.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
+  <PropertyGroup>
+    <ToolkitComponentName>Controls</ToolkitComponentName>
+    <Description>This package is a meta-package which contains all the Controls that are part of the Windows Community Toolkit. For better optimization of app package size, it is recommended before release to remove this package and include only the packages of the controls used directly, see https://aka.ms/wct/optimize.</Description>
+
+    <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
+    <RootNamespace>CommunityToolkit.WinUI.Controls.ControlsRns</RootNamespace>
+  </PropertyGroup>
+
+  <!-- Sets this up as a toolkit component's source project -->
+  <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)ReadMe.txt" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\CameraPreview\src\CommunityToolkit.WinUI.Controls.CameraPreview.csproj" />
+    <ProjectReference Include="..\..\HeaderedControls\src\CommunityToolkit.WinUI.Controls.HeaderedControls.csproj" />
+    <ProjectReference Include="..\..\ImageCropper\src\CommunityToolkit.WinUI.Controls.ImageCropper.csproj" />
+    <ProjectReference Include="..\..\LayoutTransformControl\src\CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj" />
+    <ProjectReference Include="..\..\MetadataControl\src\CommunityToolkit.WinUI.Controls.MetadataControl.csproj" />
+    <ProjectReference Include="..\..\Primitives\src\CommunityToolkit.WinUI.Controls.Primitives.csproj" />
+    <ProjectReference Include="..\..\RadialGauge\src\CommunityToolkit.WinUI.Controls.RadialGauge.csproj" />
+    <ProjectReference Include="..\..\RangeSelector\src\CommunityToolkit.WinUI.Controls.RangeSelector.csproj" />
+    <ProjectReference Include="..\..\RichSuggestBox\src\CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj" />
+    <ProjectReference Include="..\..\Segmented\src\CommunityToolkit.WinUI.Controls.Segmented.csproj" />
+    <ProjectReference Include="..\..\SettingsControls\src\CommunityToolkit.WinUI.Controls.SettingsControls.csproj" />
+    <ProjectReference Include="..\..\Sizers\src\CommunityToolkit.WinUI.Controls.Sizers.csproj" />
+    <ProjectReference Include="..\..\TokenizingTextBox\src\CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj" />
+  </ItemGroup>
+</Project>

--- a/components/Controls/src/ReadMe.txt
+++ b/components/Controls/src/ReadMe.txt
@@ -1,0 +1,45 @@
+Windows Community Toolkit — Controls
+
+Thanks for installing the “Windows Community Toolkit — UI Controls” package!
+
+This is a meta-package made up of various Windows Community Toolkit packages.
+It is for your ease and convenience to use any and all controls available!
+
+You also have the option to only use packages you need which can help optimize the
+size of your application once you are ready to ship. Visit https://aka.ms/wct/optimize to learn more.
+
+You can find out more about the Windows Community Toolkit at https://aka.ms/toolkit/windows.
+Or even try our controls in our sample app at https://aka.ms/windowstoolkitapp.
+Docs are available here: https://aka.ms/windowstoolkitdocs.
+
+The Windows Community Toolkit is made possible by our developer community!
+Every contribution made to the Toolkit helps everyone, to learn how to contribute visit https://aka.ms/wct/wiki
+or check out the Windows Community Toolkit Labs at https://aka.ms/toolkit/labs/windows.
+
+--- For UWP Based Developers ---
+
+This package also depends on the "WinUI 2" library, so you'll need to set "XamlControlsResources" as your Application resources in "App.xaml":
+
+<Application>
+    <Application.Resources>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+    </Application.Resources>
+</Application>
+
+If you have other resources, then we recommend you add those to the "XamlControlsResources.MergedDictionaries".
+This works with the platform's resource system to allow overrides of the "XamlControlsResources" resources.
+
+<Application
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+    <Application.Resources>
+        <controls:XamlControlsResources>
+            <controls:XamlControlsResources.MergedDictionaries>
+                <!-- Other app resources here -->
+            </controls:XamlControlsResources.MergedDictionaries>
+        </controls:XamlControlsResources>
+    </Application.Resources>
+</Application>
+
+See http://aka.ms/winui for more information about the "WinUI" library.


### PR DESCRIPTION
Fixes #115 

With any luck, this will just be a shell of a package which includes references to all the other packages...

We'll see what happens...

Added an updated readme we had from the old repo with the note about WinUI 2 for UWP developers, not sure if we can have two different files for WinUI 3 builds vs. WinUI 2 ones easily enough for this purpose, maybe something we can improve in the future?

Wanted to at least test to see if this even worked first though...