### PR TITLE
Updates build.yml trigger to automatically start workflow when a release branch is created

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Triggers the workflow on push or pull request events but only for the main or release branches
   push:
-    branches: [ main ]
+    branches: [ main, 'rel/*' ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Our release process then just becomes create a branch off main named `rel/major.minor.YYMMDD[-previewtag]` like I did with [8.0.230823-rc](https://github.com/CommunityToolkit/Windows/tree/rel/8.0.230823-rc).

This will then make it auto-trigger the workflow and wait to push to NuGet.org when an authorized maintainer signs-off on that step. (I had to manually start the workflow on the new branch for our first release.)

Only thing we need to do for minor/major versions is to update the directory props files ahead of that branch creation, which we should probably do along with whatever larger change we're planning to do or whatnot.