### PR TITLE
Update tooling submodule for rebrand changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,10 @@
     <RepositoryDirectory>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepositoryDirectory>
     <ToolingDirectory>$(RepositoryDirectory)tooling</ToolingDirectory>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <ToolkitExtensionSourceProject>$(RepositoryDirectory)components\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj</ToolkitExtensionSourceProject>
     <ToolkitConvertersSourceProject>$(RepositoryDirectory)components\Converters\src\CommunityToolkit.WinUI.Converters.csproj</ToolkitConvertersSourceProject>
+    <ToolkitExtensionSourceProject>$(RepositoryDirectory)components\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj</ToolkitExtensionSourceProject>
+    <ToolkitTriggersSourceProject>$(RepositoryDirectory)components\Triggers\src\CommunityToolkit.WinUI.Triggers.csproj</ToolkitTriggersSourceProject>
+    <ToolkitSettingsControlsSourceProject>$(RepositoryDirectory)components\SettingsControls\src\CommunityToolkit.WinUI.Controls.SettingsControls.csproj</ToolkitSettingsControlsSourceProject>
 
     <!-- TODO: See https://github.com/CommunityToolkit/Windows/issues/117 these should be removed unless needed by sample app or tests -->
     <ToolkitHelperSourceProject>$(RepositoryDirectory)components\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj</ToolkitHelperSourceProject>


### PR DESCRIPTION
Test PR for changes from https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/110

This may require other changes to props files here, but wanted to get it started so we wouldn't forget.