### PR TITLE
Include component icons as library assets

### DIFF
--- a/components/Animations/samples/Animations.Samples.csproj
+++ b/components/Animations/samples/Animations.Samples.csproj
@@ -13,6 +13,8 @@
     <None Remove="Assets\MitchellButtes.jpg" />
     <None Remove="Assets\OregonWineryNamaste.jpg" />
     <None Remove="Assets\RunningDogPacificCity.jpg" />
+    <None Remove="Assets\ConnectedAnimations.png" />
+    <None Remove="Assets\ImplicitAnimations.png" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\BigFourSummerHeat2.jpg">
@@ -34,6 +36,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\RunningDogPacificCity.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\ImplicitAnimations.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\ConnectedAnimations.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/components/Behaviors/samples/Behaviors.Samples.csproj
+++ b/components/Behaviors/samples/Behaviors.Samples.csproj
@@ -12,9 +12,25 @@
   
   <ItemGroup>
     <None Remove="Assets\ToolkitIcon.png" />
+    <None Remove="Assets\AnimationSet.png" />
+    <None Remove="Assets\Behaviors.png" />
+    <None Remove="Assets\HeaderBehaviors.png" />
+    <None Remove="Assets\StackedNotificationsBehavior.png" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\ToolkitIcon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\AnimationSet.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Behaviors.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\HeaderBehaviors.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\StackedNotificationsBehavior.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/components/CameraPreview/samples/CameraPreview.Samples.csproj
+++ b/components/CameraPreview/samples/CameraPreview.Samples.csproj
@@ -5,4 +5,13 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+
+  <ItemGroup>
+    <None Remove="Assets\CameraPreview.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\CameraPreview.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/Collections/samples/Collections.Samples.csproj
+++ b/components/Collections/samples/Collections.Samples.csproj
@@ -6,10 +6,18 @@
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
   <ItemGroup>
+    <None Remove="Assets\AdvancedCollectionView.png" />
     <None Remove="Assets\AppIcon.png" />
+    <None Remove="Assets\IncrementalLoadingCollection.png" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Assets\AdvancedCollectionView.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\AppIcon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\IncrementalLoadingCollection.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/components/DeveloperTools/samples/DeveloperTools.Samples.csproj
+++ b/components/DeveloperTools/samples/DeveloperTools.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\DeveloperTools.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\DeveloperTools.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/Extensions/samples/Extensions.Samples.csproj
+++ b/components/Extensions/samples/Extensions.Samples.csproj
@@ -6,10 +6,18 @@
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
   <ItemGroup>
+    <None Remove="Assets\Extensions.png" />
     <None Remove="Assets\Llama.jpg" />
+    <None Remove="Assets\Shadow.png" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Assets\Extensions.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\Llama.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Shadow.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/components/HeaderedControls/samples/HeaderedControls.Samples.csproj
+++ b/components/HeaderedControls/samples/HeaderedControls.Samples.csproj
@@ -7,10 +7,22 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
   <ItemGroup>
     <None Remove="Assets\BisonBadlandsChillin.jpg" />
+    <None Remove="Assets\HeaderedContentControl.png" />
+    <None Remove="Assets\HeaderedItemsControl.png" />
+    <None Remove="Assets\HeaderedTreeView.png" />
     <None Remove="Assets\Sunny.png" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\BisonBadlandsChillin.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\HeaderedContentControl.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\HeaderedItemsControl.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\HeaderedTreeView.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\Sunny.png">

--- a/components/Helpers/samples/Helpers.Samples.csproj
+++ b/components/Helpers/samples/Helpers.Samples.csproj
@@ -5,4 +5,32 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\CameraHelper.png" />
+    <None Remove="Assets\ColorHelper.png" />
+    <None Remove="Assets\NetworkHelper.png" />
+    <None Remove="Assets\ScreenUnitHelper.png" />
+    <None Remove="Assets\ThemeListener.png" />
+    <None Remove="Assets\WeakEventListener.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\CameraHelper.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\ColorHelper.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\NetworkHelper.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\ScreenUnitHelper.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\ThemeListener.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\WeakEventListener.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/ImageCropper/samples/ImageCropper.Samples.csproj
+++ b/components/ImageCropper/samples/ImageCropper.Samples.csproj
@@ -7,9 +7,13 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
   <ItemGroup>
     <None Remove="Assets\Owl.jpg" />
+    <None Remove="Assets\ImageCropper.png" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Owl.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\ImageCropper.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/components/LayoutTransformControl/samples/LayoutTransformControl.Samples.csproj
+++ b/components/LayoutTransformControl/samples/LayoutTransformControl.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\LayoutTransformControl.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\LayoutTransformControl.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/Media/samples/Media.Samples.csproj
+++ b/components/Media/samples/Media.Samples.csproj
@@ -8,7 +8,12 @@
   
   <ItemGroup>
     <None Remove="Assets\Bloom.jpg" />
+    <None Remove="Assets\EffectAnimations.png" />
+    
     <Content Include="Assets\Bloom.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\EffectAnimations.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/components/MetadataControl/samples/MetadataControl.Samples.csproj
+++ b/components/MetadataControl/samples/MetadataControl.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+
+  <ItemGroup>
+    <None Remove="Assets\MetadataControl.png" />
+    
+    <Content Include="Assets\MetadataControl.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/Primitives/samples/Primitives.Samples.csproj
+++ b/components/Primitives/samples/Primitives.Samples.csproj
@@ -12,16 +12,47 @@
   </ItemGroup>
   
   <ItemGroup>
+    <None Remove="Assets\BigFourSummerHeat.png" />
+    <None Remove="Assets\checker.png" />
+    <None Remove="Assets\ConstrainedBox.png" />
+    <None Remove="Assets\DockPanel.png" />
+    <None Remove="Assets\StaggeredPanel.png" />
+    <None Remove="Assets\UniformGrid.png" />
+    <None Remove="Assets\WestSeattleView.jpg" />
+    <None Remove="Assets\WrapLayout.png" />
+    <None Remove="Assets\WrapPanel.png" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <Content Include="Assets\BigFourSummerHeat.jpg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Assets\WestSeattleView.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\checker.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\ConstrainedBox.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\DockPanel.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\StaggeredPanel.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\UniformGrid.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\WestSeattleView.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\WrapLayout.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\WrapPanel.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
+  
   <ItemGroup>
     <Compile Update="UniformGridSample.xaml.cs">
       <DependentUpon>UniformGridSample.xaml</DependentUpon>

--- a/components/RadialGauge/samples/RadialGauge.Samples.csproj
+++ b/components/RadialGauge/samples/RadialGauge.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\RadialGauge.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\RadialGauge.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/RangeSelector/samples/RangeSelector.Samples.csproj
+++ b/components/RangeSelector/samples/RangeSelector.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\RangeSelector.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\RangeSelector.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/RichSuggestBox/samples/RichSuggestBox.Samples.csproj
+++ b/components/RichSuggestBox/samples/RichSuggestBox.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\RichSuggestbox.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\RichSuggestbox.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/Segmented/samples/Segmented.Samples.csproj
+++ b/components/Segmented/samples/Segmented.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\Segmented.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\Segmented.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/SettingsControls/samples/SettingsControls.Samples.csproj
+++ b/components/SettingsControls/samples/SettingsControls.Samples.csproj
@@ -9,4 +9,16 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj"></ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Assets\SettingsCard.png" />
+    <None Remove="Assets\SettingsExpander.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\SettingsCard.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\SettingsExpander.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/Sizers/samples/SizerBase.Samples.csproj
+++ b/components/Sizers/samples/SizerBase.Samples.csproj
@@ -5,4 +5,24 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\ContentSizer.png" />
+    <None Remove="Assets\GridSplitter.png" />
+    <None Remove="Assets\PropertySizer.png" />
+    <None Remove="Assets\Sizers.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\ContentSizer.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\GridSplitter.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\PropertySizer.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Sizers.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/TokenizingTextBox/samples/TokenizingTextBox.Samples.csproj
+++ b/components/TokenizingTextBox/samples/TokenizingTextBox.Samples.csproj
@@ -5,4 +5,12 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  <ItemGroup>
+    <None Remove="Assets\TokenizingTextBox.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\TokenizingTextBox.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/components/Triggers/samples/Triggers.Samples.csproj
+++ b/components/Triggers/samples/Triggers.Samples.csproj
@@ -5,6 +5,16 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+  
+  <ItemGroup>
+    <None Remove="Assets\Triggers.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\Triggers.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
   <ItemGroup>
     <Compile Update="CompareStateTriggerSample.xaml.cs">
       <DependentUpon>CompareStateTriggerSample.xaml</DependentUpon>


### PR DESCRIPTION
Needs https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/129

This PR consists of a tooling update that fixes an asset issue in the sample app.

Component icons and other `.png` files are now included as library assets instead of using the `/SourceAssets` workaround needed for this (now closed) issue: https://github.com/unoplatform/uno/issues/2502.