### PR TITLE
[SettingsExpander] Fix for CornerRadius

### DIFF
--- a/components/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
+++ b/components/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
@@ -78,6 +78,7 @@
                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        win:AutomationProperties.HelpText="{TemplateBinding AutomationProperties.HelpText}"
                                        win:AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                       CornerRadius="{TemplateBinding CornerRadius}"
                                        IsExpanded="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                        Style="{StaticResource SettingsExpanderExpanderStyle}">
                             <muxc:Expander.Header>


### PR DESCRIPTION
As pointed out by @krschau in https://github.com/CommunityToolkit/Labs-Windows/issues/216#issuecomment-1707310372

Setting the `CornerRadius` to of a `SettingsCard` and `SettingsExpander` to 100.

Before:
![image](https://github.com/CommunityToolkit/Windows/assets/9866362/7b6560c8-a372-4c80-91b2-eec19256ddd8)


After:
![image](https://github.com/CommunityToolkit/Windows/assets/9866362/3e492490-4a7a-4837-999f-7c0e0c091d60)
