### PR TITLE
Update Build so that Uwp package doesn't include WASDK and vice-versa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
 
     env:
       # faux-ternary expression to select which platforms to build for each platform vs. duplicating step below.
-      TARGET_PLATFORMS: all
+      TARGET_PLATFORMS: ${{ matrix.platform != 'WinUI3' && 'all-wasdk' || 'all-uwp' }}
       TEST_PLATFORM: ${{ matrix.platform != 'WinUI3' && 'UWP' || 'WinAppSdk' }}
       VERSION_PROPERTY: ${{ github.ref == 'refs/heads/main' && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PreviewVersion>preview</PreviewVersion>
 
     <PackageIdPrefix>CommunityToolkit</PackageIdPrefix>
     <RepositoryDirectory>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepositoryDirectory>


### PR DESCRIPTION
Fixes #220

With this change our `Uwp` based packages won't include the `net6/7-windows` targets/WASDK
And our `WinUI` packages won't include the `uap` target for UWP.

This should enable WAPProjects to better handle this scenario (we'll have to test), and mean that Uno folks can't improperly mix-and-match, they'll need to install the package that corresponds to their Uno.UI/Uno.WinUI setup.