### PR TITLE
Updating Collections namespace

### DIFF
--- a/components/Collections/samples/AdvancedCollectionView.md
+++ b/components/Collections/samples/AdvancedCollectionView.md
@@ -2,7 +2,7 @@
 title: AdvancedCollectionView
 author: nmetulev
 description: The AdvancedCollectionView is a collection view implementation that support filtering, sorting and incremental loading. It's meant to be used in a viewmodel.
-keywords: AdvancedCollectionView, data, sorting, filtering
+keywords: AdvancedCollectionView, data, sorting, filtering, Collections
 dev_langs:
   - csharp
 category: Helpers
@@ -27,7 +27,7 @@ In your viewmodel instead of having a public [IEnumerable](https://learn.microso
 ## Example
 
 ```csharp
-using CommunityToolkit.WinUI;
+using CommunityToolkit.WinUI.Collections;
 
 // Grab a sample type
 public class Person

--- a/components/Collections/samples/AdvancedCollectionViewSample.xaml
+++ b/components/Collections/samples/AdvancedCollectionViewSample.xaml
@@ -2,7 +2,6 @@
 <Page x:Class="CollectionsExperiment.Samples.AdvancedCollectionViewSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:controls="using:CommunityToolkit.WinUI"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="using:AdvancedCollectionViewExperiment.Samples"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/components/Collections/samples/AdvancedCollectionViewSample.xaml.cs
+++ b/components/Collections/samples/AdvancedCollectionViewSample.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommunityToolkit.WinUI;
+using CommunityToolkit.WinUI.Collections;
 
 namespace CollectionsExperiment.Samples;
 

--- a/components/Collections/samples/IncrementalLoadingCollection.md
+++ b/components/Collections/samples/IncrementalLoadingCollection.md
@@ -2,7 +2,7 @@
 title: IncrementalLoadingCollection
 author: nmetulev
 description: The IncrementalLoadingCollection helpers greatly simplify the definition and usage of collections whose items can be loaded incrementally only when needed by the view (such as a ScrollViewer).
-keywords: IncrementalLoadingCollection, Control, Data, Incremental, Loading
+keywords: IncrementalLoadingCollection, Control, Data, Incremental, Loading, Collections
 dev_langs:
   - csharp
 category: Helpers
@@ -24,7 +24,7 @@ icon: Assets/IncrementalLoadingCollection.png
 
 ```csharp
 // Be sure to include the using at the top of the file:
-//using CommunityToolkit.WinUI;
+//using CommunityToolkit.WinUI.Collections;
 
 public class Person
 {

--- a/components/Collections/samples/IncrementalLoadingCollectionSample.xaml
+++ b/components/Collections/samples/IncrementalLoadingCollectionSample.xaml
@@ -2,7 +2,6 @@
 <Page x:Class="CollectionsExperiment.Samples.IncrementalLoadingCollectionSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:controls="using:CommunityToolkit.WinUI"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="using:IncrementalLoadingCollectionExperiment.Samples"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/components/Collections/samples/IncrementalLoadingCollectionSample.xaml.cs
+++ b/components/Collections/samples/IncrementalLoadingCollectionSample.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommunityToolkit.WinUI;
+using CommunityToolkit.WinUI.Collections;
 
 namespace CollectionsExperiment.Samples;
 

--- a/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.Defer.cs
+++ b/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.Defer.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// A collection view implementation that supports filtering, grouping, sorting and incremental loading

--- a/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.Events.cs
+++ b/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.Events.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// A collection view implementation that supports filtering, grouping, sorting and incremental loading

--- a/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -8,7 +8,7 @@ using System.Collections.Specialized;
 using System.Runtime.CompilerServices;
 using NotifyCollectionChangedAction = global::System.Collections.Specialized.NotifyCollectionChangedAction;
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// A collection view implementation that supports filtering, sorting and incremental loading

--- a/components/Collections/src/AdvancedCollectionView/IAdvancedCollectionView.cs
+++ b/components/Collections/src/AdvancedCollectionView/IAdvancedCollectionView.cs
@@ -4,7 +4,7 @@
 
 using System.Collections;
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// Extended ICollectionView with filtering and sorting

--- a/components/Collections/src/AdvancedCollectionView/SortDescription.cs
+++ b/components/Collections/src/AdvancedCollectionView/SortDescription.cs
@@ -4,7 +4,7 @@
 
 using System.Collections;
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// Sort description

--- a/components/Collections/src/AdvancedCollectionView/SortDirection.cs
+++ b/components/Collections/src/AdvancedCollectionView/SortDirection.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// Sort direction enum

--- a/components/Collections/src/AdvancedCollectionView/VectorChangedEventArgs.cs
+++ b/components/Collections/src/AdvancedCollectionView/VectorChangedEventArgs.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// Vector changed EventArgs

--- a/components/Collections/src/IncrementalLoadingCollection/IIncrementalSource.cs
+++ b/components/Collections/src/IncrementalLoadingCollection/IIncrementalSource.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// This interface represents a data source whose items can be loaded incrementally.

--- a/components/Collections/src/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
+++ b/components/Collections/src/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CommunityToolkit.WinUI;
+namespace CommunityToolkit.WinUI.Collections;
 
 /// <summary>
 /// This class represents an <see cref="ObservableCollection{IType}"/> whose items can be loaded incrementally.

--- a/components/Collections/tests/DataSource.cs
+++ b/components/Collections/tests/DataSource.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 namespace CollectionsExperiment.Tests;
-
+using CommunityToolkit.WinUI.Collections;
 public class DataSource<T> : IIncrementalSource<T>
 {
     private readonly IEnumerable<T> items;

--- a/components/Collections/tests/DataSource.cs
+++ b/components/Collections/tests/DataSource.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 namespace CollectionsExperiment.Tests;
+
 using CommunityToolkit.WinUI.Collections;
 public class DataSource<T> : IIncrementalSource<T>
 {

--- a/components/Collections/tests/Test_AdvancedCollectionView.cs
+++ b/components/Collections/tests/Test_AdvancedCollectionView.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
 using CommunityToolkit.WinUI.Collections;
+
+using System.Runtime.CompilerServices;
 
 namespace CollectionsExperiment.Tests;
 

--- a/components/Collections/tests/Test_AdvancedCollectionView.cs
+++ b/components/Collections/tests/Test_AdvancedCollectionView.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using CommunityToolkit.WinUI.Collections;
 
 namespace CollectionsExperiment.Tests;
 

--- a/components/Collections/tests/Test_IncrementalLoadingCollection.cs
+++ b/components/Collections/tests/Test_IncrementalLoadingCollection.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CollectionsExperiment.Tests;
 using CommunityToolkit.WinUI.Collections;
+
+namespace CollectionsExperiment.Tests;
 
 [TestClass]
 public class Test_IncrementalLoadingCollection

--- a/components/Collections/tests/Test_IncrementalLoadingCollection.cs
+++ b/components/Collections/tests/Test_IncrementalLoadingCollection.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 namespace CollectionsExperiment.Tests;
+using CommunityToolkit.WinUI.Collections;
 
 [TestClass]
 public class Test_IncrementalLoadingCollection


### PR DESCRIPTION
`AdvancedCollectionView` and `IncrementalLoadingCollection` now use the `CommunityToolkit.WinUI.Collections` namespace instead of `CommunityToolkit.WinUI`