### PR TITLE
[SettingsControls] Bugfix for wrapping states

### DIFF
--- a/components/SettingsControls/samples/ClickableSettingsCardSample.xaml
+++ b/components/SettingsControls/samples/ClickableSettingsCardSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.ClickableSettingsCardSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -13,7 +13,10 @@
                                Header="A clickable SettingsCard"
                                HeaderIcon="{ui:FontIcon Glyph=&#xE799;}"
                                IsClickEnabled="True"
-                               IsEnabled="{x:Bind IsCardEnabled, Mode=OneWay}" />
+                               IsEnabled="{x:Bind IsCardEnabled, Mode=OneWay}">
+            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       Text="This is content" />
+        </controls:SettingsCard>
 
         <controls:SettingsCard ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}"
                                ActionIconToolTip="Open in new window"

--- a/components/SettingsControls/samples/SettingsCardSample.xaml
+++ b/components/SettingsControls/samples/SettingsCardSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsCardSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,6 +8,22 @@
       xmlns:ui="using:CommunityToolkit.WinUI"
       mc:Ignorable="d">
     <StackPanel Spacing="4">
+
+        <controls:SettingsCard>
+            <ComboBox SelectedIndex="0">
+                <ComboBoxItem>Option 1</ComboBoxItem>
+                <ComboBoxItem>Option 2</ComboBoxItem>
+                <ComboBoxItem>Option 3</ComboBoxItem>
+            </ComboBox>
+        </controls:SettingsCard>
+
+
+
+        <controls:SettingsCard Margin="0,0,0,120"
+                               Header="This is the Header" />
+
+
+
         <controls:SettingsCard x:Name="settingsCard"
                                Description="This is a default card, with the Header, HeaderIcon, Description and Content set."
                                Header="This is the Header"

--- a/components/SettingsControls/samples/SettingsCardSample.xaml
+++ b/components/SettingsControls/samples/SettingsCardSample.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsCardSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/components/SettingsControls/samples/SettingsCardSample.xaml
+++ b/components/SettingsControls/samples/SettingsCardSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsCardSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,21 +8,6 @@
       xmlns:ui="using:CommunityToolkit.WinUI"
       mc:Ignorable="d">
     <StackPanel Spacing="4">
-
-        <controls:SettingsCard>
-            <ComboBox SelectedIndex="0">
-                <ComboBoxItem>Option 1</ComboBoxItem>
-                <ComboBoxItem>Option 2</ComboBoxItem>
-                <ComboBoxItem>Option 3</ComboBoxItem>
-            </ComboBox>
-        </controls:SettingsCard>
-
-
-
-        <controls:SettingsCard Margin="0,0,0,120"
-                               Header="This is the Header" />
-
-
 
         <controls:SettingsCard x:Name="settingsCard"
                                Description="This is a default card, with the Header, HeaderIcon, Description and Content set."
@@ -63,5 +48,7 @@
             <Button Content="This control will wrap vertically!"
                     Style="{StaticResource AccentButtonStyle}" />
         </controls:SettingsCard>
+
+        <controls:SettingsCard Header="This is a card with a Header only" />
     </StackPanel>
 </Page>

--- a/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
+++ b/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsExpanderItemsSourceSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -258,11 +258,6 @@ public partial class SettingsCard : ButtonBase
        
     }
 
-    private void OnContentChanged(DependencyObject sender, DependencyProperty dp)
-    {
-     
-    }
-
     private void ContentAlignmentStates_Changed(object sender, VisualStateChangedEventArgs e)
     {
         // On state change, checking if the Content should be wrapped (e.g. when the card is made smaller or the ContentAlignment is set to Vertical). If the Content and the Header or Description are not null, we add spacing between the Content and the Header/Description.
@@ -275,8 +270,6 @@ public partial class SettingsCard : ButtonBase
             VisualStateManager.GoToState(this, NoContentSpacingState, true);
         }
     }
-
-
 
     private FrameworkElement? GetFocusedElement()
     {

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -44,9 +44,11 @@ public partial class SettingsCard : ButtonBase
         OnIsClickEnabledChanged();
         VisualStateManager.GoToState(this, IsEnabled ? NormalState : DisabledState, true);
         RegisterAutomation();
+        RegisterPropertyChangedCallback(ContentProperty, OnContentChanged);
         IsEnabledChanged += OnIsEnabledChanged;
     }
 
+  
     private void RegisterAutomation()
     {
         if (Header is string headerString && headerString != string.Empty)
@@ -207,6 +209,7 @@ public partial class SettingsCard : ButtonBase
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         }
+    
     }
 
     private void OnHeaderChanged()
@@ -217,7 +220,44 @@ public partial class SettingsCard : ButtonBase
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         }
+       
     }
+
+    private void OnContentChanged(DependencyObject sender, DependencyProperty dp)
+    {
+     
+    }
+
+    private void ContentAlignmentStates_Changed(object sender, VisualStateChangedEventArgs e)
+    {
+        if (e.NewState.Name == "RightWrapped" || e.NewState.Name == "RightWrappedNoIcon" || e.NewState.Name == "Vertical")
+        {
+            // Content is wrapped, check if the Header/Description is used and if the Content is empty. Only then add spacing
+
+            if (Content != null)
+            {
+                if (Header != null || Description != null)
+                {
+                    // Set spacing
+                    VisualStateManager.GoToState(this, "ContentSpacingActive", true);
+                }
+                else
+                {
+                    VisualStateManager.GoToState(this, "ContentSpacingNotActive", true);
+                }
+            }
+            else
+            {
+                VisualStateManager.GoToState(this, "ContentSpacingNotActive", true);
+            }
+        }
+        else
+        {
+            VisualStateManager.GoToState(this, "ContentSpacingNotActive", true);
+        }
+    }
+
+  
 
     private FrameworkElement? GetFocusedElement()
     {

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -375,7 +375,7 @@
                                 </VisualStateGroup>
 
                                 <VisualStateGroup x:Name="ContentSpacingStates">
-                                    <VisualState x:Name="NoContentSpacing"/>
+                                    <VisualState x:Name="NoContentSpacing" />
                                     <VisualState x:Name="ContentSpacing">
                                         <VisualState.Setters>
                                             <Setter Target="PART_RootGrid.RowSpacing" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:CommunityToolkit.WinUI.Controls"
@@ -106,7 +106,7 @@
     <Thickness x:Key="SettingsCardHeaderIconMargin">2,0,20,0</Thickness>
     <Thickness x:Key="SettingsCardActionIconMargin">14,0,0,0</Thickness>
     <x:Double x:Key="SettingsCardActionIconMaxSize">13</x:Double>
-    <Thickness x:Key="SettingsCardVerticalHeaderContentSpacing">0,8,0,0</Thickness>
+    <Thickness x:Key="SettingsCardVerticalHeaderContentSpacing">0,24,0,0</Thickness>
     <x:Double x:Key="SettingsCardWrapThreshold">476</x:Double>
     <x:Double x:Key="SettingsCardWrapNoIconThreshold">286</x:Double>
 
@@ -294,7 +294,8 @@
                                     </VisualState>
                                 </VisualStateGroup>
 
-                                <VisualStateGroup x:Name="ContentAlignmentStates">
+                                <VisualStateGroup x:Name="ContentAlignmentStates"
+                                                  CurrentStateChanged="ContentAlignmentStates_Changed">
                                     <!--  Default  -->
                                     <VisualState x:Name="Right" />
 
@@ -373,6 +374,15 @@
                                         </VisualState.StateTriggers>
                                         <VisualState.Setters>
                                             <Setter Target="PART_ContentPresenter.Visibility" Value="Collapsed" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+
+                                <VisualStateGroup x:Name="ContentSpacingStates">
+                                    <VisualState x:Name="ContentSpacingNotActive" />
+                                    <VisualState x:Name="ContentSpacingActive">
+                                        <VisualState.Setters>
+                                            <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
                                         </VisualState.Setters>
                                     </VisualState>
                                 </VisualStateGroup>

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -106,7 +106,7 @@
     <Thickness x:Key="SettingsCardHeaderIconMargin">2,0,20,0</Thickness>
     <Thickness x:Key="SettingsCardActionIconMargin">14,0,0,0</Thickness>
     <x:Double x:Key="SettingsCardActionIconMaxSize">13</x:Double>
-    <Thickness x:Key="SettingsCardVerticalHeaderContentSpacing">0,24,0,0</Thickness>
+    <x:Double x:Key="SettingsCardVerticalHeaderContentSpacing">36</x:Double>
     <x:Double x:Key="SettingsCardWrapThreshold">476</x:Double>
     <x:Double x:Key="SettingsCardWrapNoIconThreshold">286</x:Double>
 
@@ -294,8 +294,7 @@
                                     </VisualState>
                                 </VisualStateGroup>
 
-                                <VisualStateGroup x:Name="ContentAlignmentStates"
-                                                  CurrentStateChanged="ContentAlignmentStates_Changed">
+                                <VisualStateGroup x:Name="ContentAlignmentStates">
                                     <!--  Default  -->
                                     <VisualState x:Name="Right" />
 
@@ -311,7 +310,6 @@
                                             <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="1" />
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="Left" />
-                                            <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
                                             <Setter Target="HeaderPanel.Margin" Value="0" />
                                         </VisualState.Setters>
                                     </VisualState>
@@ -328,7 +326,6 @@
                                             <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="1" />
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="Left" />
-                                            <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
                                             <Setter Target="HeaderPanel.Margin" Value="0" />
                                         </VisualState.Setters>
                                     </VisualState>
@@ -360,7 +357,6 @@
                                             <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="1" />
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource TemplatedParent}}" />
-                                            <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
                                         </VisualState.Setters>
                                     </VisualState>
                                 </VisualStateGroup>
@@ -379,10 +375,10 @@
                                 </VisualStateGroup>
 
                                 <VisualStateGroup x:Name="ContentSpacingStates">
-                                    <VisualState x:Name="ContentSpacingNotActive" />
-                                    <VisualState x:Name="ContentSpacingActive">
+                                    <VisualState x:Name="NoContentSpacing"/>
+                                    <VisualState x:Name="ContentSpacing">
                                         <VisualState.Setters>
-                                            <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
+                                            <Setter Target="PART_RootGrid.RowSpacing" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
                                         </VisualState.Setters>
                                     </VisualState>
                                 </VisualStateGroup>

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -106,7 +106,7 @@
     <Thickness x:Key="SettingsCardHeaderIconMargin">2,0,20,0</Thickness>
     <Thickness x:Key="SettingsCardActionIconMargin">14,0,0,0</Thickness>
     <x:Double x:Key="SettingsCardActionIconMaxSize">13</x:Double>
-    <x:Double x:Key="SettingsCardVerticalHeaderContentSpacing">36</x:Double>
+    <x:Double x:Key="SettingsCardVerticalHeaderContentSpacing">8</x:Double>
     <x:Double x:Key="SettingsCardWrapThreshold">476</x:Double>
     <x:Double x:Key="SettingsCardWrapNoIconThreshold">286</x:Double>
 


### PR DESCRIPTION
Addressing: https://github.com/CommunityToolkit/Windows/issues/219

Before, when resizing a card where the `Content` is not set or `Content` is set but no `Header` + `Description` the spacing would be applied, resulting in https://github.com/CommunityToolkit/Windows/issues/219.

Before:
![image](https://github.com/CommunityToolkit/Windows/assets/9866362/f26f0e82-0426-4c38-925e-4d81abc092e3)


After:
![image](https://github.com/CommunityToolkit/Windows/assets/9866362/cd5fcc62-14a8-4bd1-ba1f-151f928832f2)



To test:

- Add the following XAML to a sample and resize the window:

``` xml
 <controls:SettingsCard >
     <ComboBox SelectedIndex="0">
         <ComboBoxItem>Option 1</ComboBoxItem>
         <ComboBoxItem>Option 2</ComboBoxItem>
         <ComboBoxItem>Option 3</ComboBoxItem>
     </ComboBox>
 </controls:SettingsCard>
```
