### PR TITLE
Fixed compositor nullreference in WinUI 3

### DIFF
--- a/components/Media/src/Brushes/BackdropGammaTransferBrush.cs
+++ b/components/Media/src/Brushes/BackdropGammaTransferBrush.cs
@@ -345,7 +345,14 @@ public class BackdropGammaTransferBrush : XamlCompositionBrushBase
                 return;
             }
 
-            var backdrop = Window.Current.Compositor.CreateBackdropBrush();
+            
+#if WINUI2
+            var compositor = Window.Current.Compositor;
+#elif WINUI3
+            var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
+
+            var backdrop = compositor.CreateBackdropBrush();
 
             // Use a Win2D blur affect applied to a CompositionBackdropBrush.
             var graphicsEffect = new GammaTransferEffect
@@ -370,7 +377,7 @@ public class BackdropGammaTransferBrush : XamlCompositionBrushBase
                 Source = new CompositionEffectSourceParameter("backdrop")
             };
 
-            var effectFactory = Window.Current.Compositor.CreateEffectFactory(graphicsEffect, new[]
+            var effectFactory = compositor.CreateEffectFactory(graphicsEffect, new[]
             {
                 "GammaTransfer.AlphaAmplitude",
                 "GammaTransfer.AlphaExponent",

--- a/components/Media/src/Brushes/CanvasBrushBase.cs
+++ b/components/Media/src/Brushes/CanvasBrushBase.cs
@@ -66,7 +66,13 @@ public abstract class CanvasBrushBase : XamlCompositionBrushBase
             _graphics.RenderingDeviceReplaced -= CanvasDevice_RenderingDeviceReplaced;
         }
 
-        _graphics = CanvasComposition.CreateCompositionGraphicsDevice(Window.Current.Compositor, _device);
+#if WINUI2
+        var compositor = Window.Current.Compositor;
+#elif WINUI3
+        var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
+
+        _graphics = CanvasComposition.CreateCompositionGraphicsDevice(compositor, _device);
         _graphics.RenderingDeviceReplaced += CanvasDevice_RenderingDeviceReplaced;
 
         // Delay creating composition resources until they're required.
@@ -95,7 +101,7 @@ public abstract class CanvasBrushBase : XamlCompositionBrushBase
                 }
             }
 
-            _surfaceBrush = Window.Current.Compositor.CreateSurfaceBrush(surface);
+            _surfaceBrush = compositor.CreateSurfaceBrush(surface);
             _surfaceBrush.Stretch = CompositionStretch.Fill;
 
             CompositionBrush = _surfaceBrush;

--- a/components/Media/src/Brushes/ImageBlendBrush.cs
+++ b/components/Media/src/Brushes/ImageBlendBrush.cs
@@ -126,6 +126,12 @@ public class ImageBlendBrush : XamlCompositionBrushBase
     /// <inheritdoc/>
     protected override void OnConnected()
     {
+#if WINUI2
+        var compositor = Window.Current.Compositor;
+#elif WINUI3
+        var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
+
         // Delay creating composition resources until they're required.
         if (CompositionBrush == null && Source != null && Source is BitmapImage bitmap)
         {
@@ -133,8 +139,9 @@ public class ImageBlendBrush : XamlCompositionBrushBase
             // If UriSource is invalid, StartLoadFromUri will return a blank texture.
             _surface = LoadedImageSurface.StartLoadFromUri(bitmap.UriSource);
 
+
             // Load Surface onto SurfaceBrush
-            _surfaceBrush = Window.Current.Compositor.CreateSurfaceBrush(_surface);
+            _surfaceBrush = compositor.CreateSurfaceBrush(_surface);
             _surfaceBrush.Stretch = CompositionStretchFromStretch(Stretch);
 
 #if WINUI2
@@ -150,7 +157,7 @@ public class ImageBlendBrush : XamlCompositionBrushBase
                 return;
             }
 
-            var backdrop = Window.Current.Compositor.CreateBackdropBrush();
+            var backdrop = compositor.CreateBackdropBrush();
 
             // Use a Win2D invert affect applied to a CompositionBackdropBrush.
             var graphicsEffect = new CanvasBlendEffect
@@ -161,7 +168,7 @@ public class ImageBlendBrush : XamlCompositionBrushBase
                 Foreground = new CompositionEffectSourceParameter("image")
             };
 
-            var effectFactory = Window.Current.Compositor.CreateEffectFactory(graphicsEffect);
+            var effectFactory = compositor.CreateEffectFactory(graphicsEffect);
             var effectBrush = effectFactory.CreateBrush();
 
             effectBrush.SetSourceParameter("backdrop", backdrop);

--- a/components/Media/src/Helpers/SurfaceLoader.Instance.cs
+++ b/components/Media/src/Helpers/SurfaceLoader.Instance.cs
@@ -43,7 +43,12 @@ public sealed partial class SurfaceLoader : IDisposable
     /// <returns>A <see cref="SurfaceLoader"/> instance to use in the current window</returns>
     public static SurfaceLoader GetInstance()
     {
-        return GetInstance(Window.Current.Compositor);
+#if WINUI2
+        var compositor = Window.Current.Compositor;
+#elif WINUI3
+        var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
+        return GetInstance(compositor);
     }
 
     /// <summary>

--- a/components/Media/src/Helpers/SurfaceLoader.cs
+++ b/components/Media/src/Helpers/SurfaceLoader.cs
@@ -44,7 +44,11 @@ public sealed partial class SurfaceLoader
     /// <returns>A <see cref="Task{T}"/> that returns the loaded <see cref="CompositionBrush"/> instance</returns>
     public static async Task<CompositionBrush?> LoadImageAsync(Uri uri, DpiMode dpiMode, CacheMode cacheMode = CacheMode.Default)
     {
+#if WINUI2
         var compositor = Window.Current.Compositor;
+#elif WINUI3
+        var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
 
         // Lock and check the cache first
         using (await Win2DMutex.LockAsync())

--- a/components/Media/src/Pipelines/PipelineBuilder.Initialization.cs
+++ b/components/Media/src/Pipelines/PipelineBuilder.Initialization.cs
@@ -46,7 +46,12 @@ public sealed partial class PipelineBuilder
     {
         ValueTask<CompositionBrush> Factory()
         {
-            var brush = BackdropBrushCache.GetValue(Window.Current.Compositor, c => c.CreateBackdropBrush());
+#if WINUI2
+            var compositor = Window.Current.Compositor;
+#elif WINUI3
+            var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
+            var brush = BackdropBrushCache.GetValue(compositor, c => c.CreateBackdropBrush());
 
             return new ValueTask<CompositionBrush>(brush);
         }

--- a/components/Media/src/Pipelines/PipelineBuilder.cs
+++ b/components/Media/src/Pipelines/PipelineBuilder.cs
@@ -160,6 +160,12 @@ public sealed partial class PipelineBuilder
     [Pure]
     public async Task<CompositionBrush> BuildAsync()
     {
+#if WINUI2
+        var compositor = Window.Current.Compositor;
+#elif WINUI3
+        var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
+
         var effect = await this.sourceProducer() as IGraphicsEffect;
 
         // Validate the pipeline
@@ -170,8 +176,8 @@ public sealed partial class PipelineBuilder
 
         // Build the effects factory
         var factory = this.animationProperties.Count > 0
-            ? Window.Current.Compositor.CreateEffectFactory(effect, this.animationProperties)
-            : Window.Current.Compositor.CreateEffectFactory(effect);
+            ? compositor.CreateEffectFactory(effect, this.animationProperties)
+            : compositor.CreateEffectFactory(effect);
 
         // Create the effect factory and apply the final effect
         var effectBrush = factory.CreateBrush();
@@ -191,7 +197,13 @@ public sealed partial class PipelineBuilder
     /// <returns>A <see cref="Task{T}"/> that returns the final <see cref="SpriteVisual"/> instance to use</returns>
     public async Task<SpriteVisual> AttachAsync(UIElement target, UIElement? reference = null)
     {
-        SpriteVisual visual = Window.Current.Compositor.CreateSpriteVisual();
+#if WINUI2
+        var compositor = Window.Current.Compositor;
+#elif WINUI3
+        var compositor = CompositionTarget.GetCompositorForCurrentThread();
+#endif
+
+        SpriteVisual visual = compositor.CreateSpriteVisual();
 
         visual.Brush = await BuildAsync();
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

This PR closes #235, #233

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Summary

Introduces a hotfix for a regression in the WinUI 3 package where usage of the compositor in the PipelineBuilder resulted in a `NullReferenceException`, caused by usage of `Window.Current.Compositor` instead of the WinUI 3 equivalent.

Still unable to launch the Wasdk sample app head for both the single-component Media solution and the gallery due to #212 and #169. These changes were tested by producing NuGet packages and testing in a blank Wasdk app. 

<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

<!-- - Bugfix -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [ ] Header has been added to all new source files
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->
