### PR TITLE
Fixing crash when setting empty string for SettingsCard's Header and Description

### DIFF
--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -247,20 +247,20 @@ public partial class SettingsCard : ButtonBase
     {
         if (GetTemplateChild(DescriptionPresenter) is FrameworkElement descriptionPresenter)
         {
-            descriptionPresenter.Visibility = Description != null
-                ? Visibility.Visible
-                : Visibility.Collapsed;
+            descriptionPresenter.Visibility = IsNullOrEmptyString(Description)
+                ? Visibility.Collapsed
+                : Visibility.Visible;
         }
-    
+
     }
 
     private void OnHeaderChanged()
     {
         if (GetTemplateChild(HeaderPresenter) is FrameworkElement headerPresenter)
         {
-            headerPresenter.Visibility = Header != null
-                ? Visibility.Visible
-                : Visibility.Collapsed;
+            headerPresenter.Visibility = IsNullOrEmptyString(Header)
+                ? Visibility.Collapsed
+                : Visibility.Visible;
         }
        
     }
@@ -274,7 +274,7 @@ public partial class SettingsCard : ButtonBase
     {
         // On state change, checking if the Content should be wrapped (e.g. when the card is made smaller or the ContentAlignment is set to Vertical). If the Content and the Header or Description are not null, we add spacing between the Content and the Header/Description.
 
-        if (s != null && (s.Name == RightWrappedState || s.Name == RightWrappedNoIconState || s.Name == VerticalState) && (Content != null) && (Header != null || Description != null))
+        if (s != null && (s.Name == RightWrappedState || s.Name == RightWrappedNoIconState || s.Name == VerticalState) && (Content != null) && (!IsNullOrEmptyString(Header) || !IsNullOrEmptyString(Description)))
         {
             VisualStateManager.GoToState(this, ContentSpacingState, true);
         }
@@ -294,5 +294,20 @@ public partial class SettingsCard : ButtonBase
         {
             return FocusManager.GetFocusedElement() as FrameworkElement;
         }
+    }
+
+    private static bool IsNullOrEmptyString(object obj)
+    {
+        if (obj == null)
+        {
+            return true;
+        }
+
+        if (obj is string objString && objString == string.Empty)
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/components/SettingsControls/tests/Test_SettingsCard.cs
+++ b/components/SettingsControls/tests/Test_SettingsCard.cs
@@ -11,6 +11,20 @@ namespace SettingsControlsExperiment.Tests;
 [TestClass]
 public partial class SettingsCardTestClass : VisualUITestBase
 {
+    [UIThreadTestMethod]
+    public void EmptyNameTest(SettingsCard card)
+    {
+        // See https://github.com/CommunityToolkit/Windows/issues/310#issue-2066181868
+        card.Name = string.Empty;
+    }
+
+    [UIThreadTestMethod]
+    public void EmptyDescriptionTest(SettingsCard card)
+    {
+        // See https://github.com/CommunityToolkit/Windows/issues/310#issue-2066181868
+        card.Description = string.Empty;
+    }
+
     // If you don't need access to UI objects directly or async code, use this pattern.
     [TestMethod]
     public void SimpleSynchronousExampleTest()


### PR DESCRIPTION
## Fixes #310 
There was a crash when binding an empty string to Header or Description while the content of SettingsCard was set. This pull request fixes that issue.

## PR Type
Bugfix

## What is the current behavior?
When the content of SettingsCard is set, binding an empty string to Header or Description causes a crash.

## What is the new behavior?
When the content of SettingsCard is set, binding an empty string to Header or Description will no longer result in a crash.

## PR Checklist
Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [ ] Header has been added to all new source files
- [x] Contains **NO** breaking changes

## Other information
I would like to explain the fixes in this pull request using XAML simplified for the SettingsCard:

- When initializing the component with the Content property (here, Header) of the ContentPresenter for the Header set to null, a crash occurs due to the ContentPresenter for the Content.
- If the Visibility of the ContentPresenter for the Header is Collapsed during this initialization, it avoids the crash.
- In SettingsCard.cs, if Header is null, it doesn't crash because the OnHeaderChanged function sets the Visibility to Collapsed.
- The problem arises when an empty string is set as the Content in the ContentPresenter; it is treated equivalently to null, but the OnHeaderChanged function does not handle empty string.
- In this pull request, fixes are implemented to check for empty strings within the OnHeaderChanged and OnDescriptionChanged functions.

```xml
<Style TargetType="local:Temp">
    <Style.Setters>
        <Setter Property="Template">
            <Setter.Value>
                <ControlTemplate TargetType="local:Temp">
                    <StackPanel>
                        <ContentPresenter x:Name="PART_HeaderPresenter"
                                          Content="{TemplateBinding Header}"/>
                        <ContentPresenter Content="{TemplateBinding Content}"/>
                    </StackPanel>
                </ControlTemplate>
            </Setter.Value>
        </Setter>
    </Style.Setters>
</Style>
```