### PR TITLE
Cleanup project references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <ToolkitHelperSourceProject>$(RepositoryDirectory)components\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj</ToolkitHelperSourceProject>
     <ToolkitBehaviorSourceProject>$(RepositoryDirectory)components\Behaviors\src\CommunityToolkit.WinUI.Behaviors.csproj</ToolkitBehaviorSourceProject>
     <ToolkitAnimationSourceProject>$(RepositoryDirectory)components\Animations\src\CommunityToolkit.WinUI.Animations.csproj</ToolkitAnimationSourceProject>
-    <ToolkitPrimitiveSourceProject>$(RepositoryDirectory)components\Primitives\src\CommunityToolkit.WinUI.Controls.Primitives.csproj</ToolkitPrimitiveSourceProject>
+    <ToolkitPrimitivesSourceProject>$(RepositoryDirectory)components\Primitives\src\CommunityToolkit.WinUI.Controls.Primitives.csproj</ToolkitPrimitivesSourceProject>
     <ToolkitSizersSourceProject>$(RepositoryDirectory)components\Sizers\src\CommunityToolkit.WinUI.Controls.Sizers.csproj</ToolkitSizersSourceProject>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <!-- TODO: See https://github.com/CommunityToolkit/Windows/issues/117 these should be removed unless needed by sample app or tests -->
     <ToolkitHelpersSourceProject>$(RepositoryDirectory)components\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj</ToolkitHelpersSourceProject>
     <ToolkitBehaviorsSourceProject>$(RepositoryDirectory)components\Behaviors\src\CommunityToolkit.WinUI.Behaviors.csproj</ToolkitBehaviorsSourceProject>
-    <ToolkitAnimationSourceProject>$(RepositoryDirectory)components\Animations\src\CommunityToolkit.WinUI.Animations.csproj</ToolkitAnimationSourceProject>
+    <ToolkitAnimationsSourceProject>$(RepositoryDirectory)components\Animations\src\CommunityToolkit.WinUI.Animations.csproj</ToolkitAnimationsSourceProject>
     <ToolkitPrimitivesSourceProject>$(RepositoryDirectory)components\Primitives\src\CommunityToolkit.WinUI.Controls.Primitives.csproj</ToolkitPrimitivesSourceProject>
     <ToolkitSizersSourceProject>$(RepositoryDirectory)components\Sizers\src\CommunityToolkit.WinUI.Controls.Sizers.csproj</ToolkitSizersSourceProject>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <ToolkitSettingsControlsSourceProject>$(RepositoryDirectory)components\SettingsControls\src\CommunityToolkit.WinUI.Controls.SettingsControls.csproj</ToolkitSettingsControlsSourceProject>
 
     <!-- TODO: See https://github.com/CommunityToolkit/Windows/issues/117 these should be removed unless needed by sample app or tests -->
-    <ToolkitHelperSourceProject>$(RepositoryDirectory)components\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj</ToolkitHelperSourceProject>
+    <ToolkitHelpersSourceProject>$(RepositoryDirectory)components\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj</ToolkitHelpersSourceProject>
     <ToolkitBehaviorSourceProject>$(RepositoryDirectory)components\Behaviors\src\CommunityToolkit.WinUI.Behaviors.csproj</ToolkitBehaviorSourceProject>
     <ToolkitAnimationSourceProject>$(RepositoryDirectory)components\Animations\src\CommunityToolkit.WinUI.Animations.csproj</ToolkitAnimationSourceProject>
     <ToolkitPrimitivesSourceProject>$(RepositoryDirectory)components\Primitives\src\CommunityToolkit.WinUI.Controls.Primitives.csproj</ToolkitPrimitivesSourceProject>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
     <ToolkitBehaviorSourceProject>$(RepositoryDirectory)components\Behaviors\src\CommunityToolkit.WinUI.Behaviors.csproj</ToolkitBehaviorSourceProject>
     <ToolkitAnimationSourceProject>$(RepositoryDirectory)components\Animations\src\CommunityToolkit.WinUI.Animations.csproj</ToolkitAnimationSourceProject>
     <ToolkitPrimitiveSourceProject>$(RepositoryDirectory)components\Primitives\src\CommunityToolkit.WinUI.Controls.Primitives.csproj</ToolkitPrimitiveSourceProject>
+    <ToolkitSizersSourceProject>$(RepositoryDirectory)components\Sizers\src\CommunityToolkit.WinUI.Controls.Sizers.csproj</ToolkitSizersSourceProject>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
 
     <!-- TODO: See https://github.com/CommunityToolkit/Windows/issues/117 these should be removed unless needed by sample app or tests -->
     <ToolkitHelpersSourceProject>$(RepositoryDirectory)components\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj</ToolkitHelpersSourceProject>
-    <ToolkitBehaviorSourceProject>$(RepositoryDirectory)components\Behaviors\src\CommunityToolkit.WinUI.Behaviors.csproj</ToolkitBehaviorSourceProject>
+    <ToolkitBehaviorsSourceProject>$(RepositoryDirectory)components\Behaviors\src\CommunityToolkit.WinUI.Behaviors.csproj</ToolkitBehaviorsSourceProject>
     <ToolkitAnimationSourceProject>$(RepositoryDirectory)components\Animations\src\CommunityToolkit.WinUI.Animations.csproj</ToolkitAnimationSourceProject>
     <ToolkitPrimitivesSourceProject>$(RepositoryDirectory)components\Primitives\src\CommunityToolkit.WinUI.Controls.Primitives.csproj</ToolkitPrimitivesSourceProject>
     <ToolkitSizersSourceProject>$(RepositoryDirectory)components\Sizers\src\CommunityToolkit.WinUI.Controls.Sizers.csproj</ToolkitSizersSourceProject>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <ToolingDirectory>$(RepositoryDirectory)tooling</ToolingDirectory>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <ToolkitConvertersSourceProject>$(RepositoryDirectory)components\Converters\src\CommunityToolkit.WinUI.Converters.csproj</ToolkitConvertersSourceProject>
-    <ToolkitExtensionSourceProject>$(RepositoryDirectory)components\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj</ToolkitExtensionSourceProject>
+    <ToolkitExtensionsSourceProject>$(RepositoryDirectory)components\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj</ToolkitExtensionsSourceProject>
     <ToolkitTriggersSourceProject>$(RepositoryDirectory)components\Triggers\src\CommunityToolkit.WinUI.Triggers.csproj</ToolkitTriggersSourceProject>
     <ToolkitSettingsControlsSourceProject>$(RepositoryDirectory)components\SettingsControls\src\CommunityToolkit.WinUI.Controls.SettingsControls.csproj</ToolkitSettingsControlsSourceProject>
 

--- a/components/Animations/samples/Animations.Samples.csproj
+++ b/components/Animations/samples/Animations.Samples.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/components/Animations/src/CommunityToolkit.WinUI.Animations.csproj
+++ b/components/Animations/src/CommunityToolkit.WinUI.Animations.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)" />
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
+++ b/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
@@ -20,6 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(ToolkitAnimationSourceProject)" />
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)" />
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 </Project>

--- a/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
+++ b/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitAnimationSourceProject)" />
+    <ProjectReference Include="$(ToolkitAnimationsSourceProject)" />
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 </Project>

--- a/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
+++ b/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitHelperSourceProject)"/>
+    <ProjectReference Include="$(ToolkitHelpersSourceProject)"/>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/Collections/src/CommunityToolkit.WinUI.Collections.csproj
+++ b/components/Collections/src/CommunityToolkit.WinUI.Collections.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitHelperSourceProject)"/>
+    <ProjectReference Include="$(ToolkitHelpersSourceProject)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/components/Helpers/src/CommunityToolkit.WinUI.Helpers.csproj
+++ b/components/Helpers/src/CommunityToolkit.WinUI.Helpers.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/components/ImageCropper/src/CommunityToolkit.WinUI.Controls.ImageCropper.csproj
+++ b/components/ImageCropper/src/CommunityToolkit.WinUI.Controls.ImageCropper.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
+++ b/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
   
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/Media/samples/Dependencies.props
+++ b/components/Media/samples/Dependencies.props
@@ -11,21 +11,17 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.0-beta.2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.0-beta.2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.0-beta.2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.0-beta.2"/>
   </ItemGroup>
 </Project>

--- a/components/Media/samples/Media.Samples.csproj
+++ b/components/Media/samples/Media.Samples.csproj
@@ -5,6 +5,10 @@
 
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="$(ToolkitBehaviorsSourceProject)" />
+  </ItemGroup>
   
   <ItemGroup>
     <None Remove="Assets\Bloom.jpg" />

--- a/components/Media/samples/Media.Samples.csproj
+++ b/components/Media/samples/Media.Samples.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitBehaviorSourceProject)" />
+    <ProjectReference Include="$(ToolkitBehaviorsSourceProject)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/components/Media/samples/Media.Samples.csproj
+++ b/components/Media/samples/Media.Samples.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitBehaviorsSourceProject)" />
+    <ProjectReference Include="$(ToolkitBehaviorSourceProject)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/components/Media/src/CommunityToolkit.WinUI.Media.csproj
+++ b/components/Media/src/CommunityToolkit.WinUI.Media.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitAnimationSourceProject)" />
+    <ProjectReference Include="$(ToolkitAnimationsSourceProject)" />
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 </Project>

--- a/components/Primitives/samples/Primitives.Samples.csproj
+++ b/components/Primitives/samples/Primitives.Samples.csproj
@@ -7,8 +7,8 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj"></ProjectReference>
-    <ProjectReference Include="..\..\Sizers\src\CommunityToolkit.WinUI.Controls.Sizers.csproj"></ProjectReference>
+    <ProjectReference Include="$(ToolkitExtensionSourceProject)"></ProjectReference>
+    <ProjectReference Include="$(ToolkitSizersSourceProject)"></ProjectReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/components/Primitives/samples/Primitives.Samples.csproj
+++ b/components/Primitives/samples/Primitives.Samples.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"></ProjectReference>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"></ProjectReference>
     <ProjectReference Include="$(ToolkitSizersSourceProject)"></ProjectReference>
   </ItemGroup>
   

--- a/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
+++ b/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"></ProjectReference>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"></ProjectReference>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
+++ b/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj"></ProjectReference>
+    <ProjectReference Include="$(ToolkitExtensionSourceProject)"></ProjectReference>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
+++ b/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitHelperSourceProject)" />
+    <ProjectReference Include="$(ToolkitHelpersSourceProject)" />
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 

--- a/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
+++ b/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(ToolkitHelperSourceProject)" />
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)" />
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
+++ b/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Helpers\src\CommunityToolkit.WinUI.Helpers.csproj" />
-    <ProjectReference Include="..\..\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj" />
+    <ProjectReference Include="$(ToolkitHelperSourceProject)" />
+    <ProjectReference Include="$(ToolkitExtensionSourceProject)" />
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
+++ b/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
+++ b/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/Segmented/samples/Segmented.Samples.csproj
+++ b/components/Segmented/samples/Segmented.Samples.csproj
@@ -6,7 +6,7 @@
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
   <ItemGroup>
     <None Remove="Assets\Segmented.png" />

--- a/components/Segmented/samples/Segmented.Samples.csproj
+++ b/components/Segmented/samples/Segmented.Samples.csproj
@@ -6,7 +6,7 @@
   <!-- Sets this up as a toolkit component's sample project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
   <ItemGroup>
-    <ProjectReference Include="..\..\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj"/>
+    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
   </ItemGroup>
   <ItemGroup>
     <None Remove="Assets\Segmented.png" />

--- a/components/Segmented/src/CommunityToolkit.WinUI.Controls.Segmented.csproj
+++ b/components/Segmented/src/CommunityToolkit.WinUI.Controls.Segmented.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/SettingsControls/samples/SettingsControls.Samples.csproj
+++ b/components/SettingsControls/samples/SettingsControls.Samples.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Extensions\src\CommunityToolkit.WinUI.Extensions.csproj"></ProjectReference>
+    <ProjectReference Include="$(ToolkitExtensionSourceProject)"></ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Remove="Assets\SettingsCard.png" />

--- a/components/SettingsControls/samples/SettingsControls.Samples.csproj
+++ b/components/SettingsControls/samples/SettingsControls.Samples.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SampleProject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)"></ProjectReference>
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)"></ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Remove="Assets\SettingsCard.png" />

--- a/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
+++ b/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Triggers\src\CommunityToolkit.WinUI.Triggers.csproj"></ProjectReference>
+    <ProjectReference Include="$(ToolkitTriggersSourceProject)"></ProjectReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
+++ b/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)" />
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
+++ b/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
-    <ProjectReference Include="$(ToolkitHelperSourceProject)" />
+    <ProjectReference Include="$(ToolkitHelpersSourceProject)" />
     <ProjectReference Include="$(ToolkitPrimitivesSourceProject)" />    
   </ItemGroup>
 

--- a/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
+++ b/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
     <ProjectReference Include="$(ToolkitHelperSourceProject)" />
-    <ProjectReference Include="$(ToolkitPrimitiveSourceProject)" />    
+    <ProjectReference Include="$(ToolkitPrimitivesSourceProject)" />    
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
+++ b/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitExtensionSourceProject)" />
+    <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
     <ProjectReference Include="$(ToolkitHelperSourceProject)" />
     <ProjectReference Include="$(ToolkitPrimitiveSourceProject)" />    
   </ItemGroup>

--- a/components/Triggers/src/CommunityToolkit.WinUI.Triggers.csproj
+++ b/components/Triggers/src/CommunityToolkit.WinUI.Triggers.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(ToolkitHelperSourceProject)" />
+    <ProjectReference Include="$(ToolkitHelpersSourceProject)" />
   </ItemGroup>
 
   <!-- Sets this up as a toolkit component's source project -->


### PR DESCRIPTION
This PR:
- Fixes #212
- Fixes all usages of relative ProjectReference paths to be relative to repo root
- Fixes malformed references to `ToolkitBehaviorsSourceProject` and `ToolkitExtensionsSourceProject`
- Fixed any source path prop names defined in Directory.Build.props that didn't match the component name

Prerequisite PR: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/163