### PR TITLE
Disable Implicit animations when running under Uno

### DIFF
--- a/components/Animations/src/Implicit.cs
+++ b/components/Animations/src/Implicit.cs
@@ -129,6 +129,11 @@ public static class Implicit
     /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance for the current event.</param>
     private static void OnShowAnimationsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
+        // See https://github.com/CommunityToolkit/Windows/issues/319
+        #if HAS_UNO
+            return;
+        #endif
+
         static void OnAnimationsChanged(object sender, EventArgs e)
         {
             var collection = (ImplicitAnimationSet)sender;
@@ -169,6 +174,11 @@ public static class Implicit
     /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance for the current event.</param>
     private static void OnHideAnimationsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
+        // See https://github.com/CommunityToolkit/Windows/issues/319
+        #if HAS_UNO
+            return;
+        #endif
+
         static void OnAnimationsChanged(object sender, EventArgs e)
         {
             var collection = (ImplicitAnimationSet)sender;
@@ -209,6 +219,11 @@ public static class Implicit
     /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance for the current event.</param>
     private static void OnAnimationsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
+        // See https://github.com/CommunityToolkit/Windows/issues/319
+        #if HAS_UNO
+            return;
+        #endif
+
         static void OnAnimationsChanged(object sender, EventArgs e)
         {
             var collection = (ImplicitAnimationSet)sender;

--- a/components/Animations/src/Implicit.cs
+++ b/components/Animations/src/Implicit.cs
@@ -131,6 +131,7 @@ public static class Implicit
     {
         // See https://github.com/CommunityToolkit/Windows/issues/319
         #if HAS_UNO
+        #pragma warning disable CS0162
             return;
         #endif
 
@@ -165,6 +166,10 @@ public static class Implicit
                 ElementCompositionPreview.SetImplicitShowAnimation(element, null);
             }
         }
+
+        #if HAS_UNO
+        #pragma warning restore CS0162
+        #endif
     }
 
     /// <summary>
@@ -176,6 +181,7 @@ public static class Implicit
     {
         // See https://github.com/CommunityToolkit/Windows/issues/319
         #if HAS_UNO
+        #pragma warning disable CS0162
             return;
         #endif
 
@@ -210,6 +216,10 @@ public static class Implicit
                 ElementCompositionPreview.SetImplicitHideAnimation(element, null);
             }
         }
+
+        #if HAS_UNO
+        #pragma warning restore CS0162
+        #endif
     }
 
     /// <summary>
@@ -221,6 +231,7 @@ public static class Implicit
     {
         // See https://github.com/CommunityToolkit/Windows/issues/319
         #if HAS_UNO
+        #pragma warning disable CS0162
             return;
         #endif
 
@@ -255,5 +266,9 @@ public static class Implicit
                 ElementCompositionPreview.GetElementVisual(element).ImplicitAnimations = null;
             }
         }
+
+        #if HAS_UNO
+        #pragma warning restore CS0162
+        #endif
     }
 }


### PR DESCRIPTION
Progress towards #319
Needed for #241
See also https://github.com/CommunityToolkit/Windows/pull/241#issuecomment-1899107130

This PR disables calls to the Composition APIs in the Implicit animation attached property when running under Uno.