### PR TITLE
Added missing package descriptions

### DIFF
--- a/components/Animations/src/CommunityToolkit.WinUI.Animations.csproj
+++ b/components/Animations/src/CommunityToolkit.WinUI.Animations.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Animations</ToolkitComponentName>
-    <Description>This package contains Animations.</Description>
+    <Description>A collection of implicit, composition and connected animation helpers and builders.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.AnimationsRns</RootNamespace>

--- a/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
+++ b/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Behaviors</ToolkitComponentName>
-    <Description>The Microsoft.Xaml.Behaviors.* packages contains several useful inbox triggers and actions, and the Windows Community Toolkit provides even more.</Description>
+    <Description>A collection of useful triggers and actions to supplement Microsoft.Xaml.Behaviors.*.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.BehaviorsRns</RootNamespace>

--- a/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
+++ b/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Behaviors</ToolkitComponentName>
-    <Description>This package contains Behaviors.</Description>
+    <Description>The Microsoft.Xaml.Behaviors.* packages contains several useful inbox triggers and actions, and the Windows Community Toolkit provides even more.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.BehaviorsRns</RootNamespace>

--- a/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
+++ b/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>CameraPreview</ToolkitComponentName>
-    <Description>This package contains CameraPreview.</Description>
+    <Description>Enables easily previewing video in the MediaPlayerElement from available camera frame source groups.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.CameraPreviewRns</RootNamespace>

--- a/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
+++ b/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))')" />
   <PropertyGroup>
     <ToolkitComponentName>ColorPicker</ToolkitComponentName>
-    <Description>This package contains ColorPicker.</Description>
+    <Description>An extended color picker that enables picking a color using a spectrum, sliders, or text input.</Description>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.ColorPickerRns</RootNamespace>

--- a/components/Converters/src/CommunityToolkit.WinUI.Converters.csproj
+++ b/components/Converters/src/CommunityToolkit.WinUI.Converters.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Converters</ToolkitComponentName>
-    <Description>This package contains Converters.</Description>
+    <Description>Commonly used converters that allow the data to be modified as it passes through the binding engine.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.ConvertersRns</RootNamespace>

--- a/components/DeveloperTools/src/CommunityToolkit.WinUI.DeveloperTools.csproj
+++ b/components/DeveloperTools/src/CommunityToolkit.WinUI.DeveloperTools.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>DeveloperTools</ToolkitComponentName>
-    <Description>This package contains DeveloperTools.</Description>
+    <Description>The FocusTracker and AlignmentGrid help you to get more information about and aligning UI elements.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.DeveloperToolsRns</RootNamespace>

--- a/components/DeveloperTools/src/CommunityToolkit.WinUI.DeveloperTools.csproj
+++ b/components/DeveloperTools/src/CommunityToolkit.WinUI.DeveloperTools.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>DeveloperTools</ToolkitComponentName>
-    <Description>The FocusTracker and AlignmentGrid help you to get more information about and aligning UI elements.</Description>
+    <Description>The FocusTracker and AlignmentGrid help you to get more information about aligning UI elements.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.DeveloperToolsRns</RootNamespace>

--- a/components/Extensions/src/CommunityToolkit.WinUI.Extensions.csproj
+++ b/components/Extensions/src/CommunityToolkit.WinUI.Extensions.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Extensions</ToolkitComponentName>
-    <Description>This package contains Extensions.</Description>
+    <Description>This package contains various Extensions for text, framework components (dispatcher, visual tree, FrameworkElement, etc.), visual transforms, shadows, ScrollViewer, ListViewBase, and more.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.ExtensionsRns</RootNamespace>

--- a/components/HeaderedControls/src/CommunityToolkit.WinUI.Controls.HeaderedControls.csproj
+++ b/components/HeaderedControls/src/CommunityToolkit.WinUI.Controls.HeaderedControls.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>HeaderedControls</ToolkitComponentName>
-    <Description>This package contains HeaderedControls.</Description>
+    <Description>This package contains controls such as HeaderedItemsControl, HeaderedTreeView, and HeaderedContentControl.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.HeaderedControlsRns</RootNamespace>

--- a/components/Helpers/src/CommunityToolkit.WinUI.Helpers.csproj
+++ b/components/Helpers/src/CommunityToolkit.WinUI.Helpers.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Helpers</ToolkitComponentName>
-    <Description>This package contains Helpers.</Description>
+    <Description>This package contains various helpers for Colors, Network, Camera, WeakEventListener, PackageVersion, ScreenUnit and more.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.HelpersRns</RootNamespace>

--- a/components/ImageCropper/src/CommunityToolkit.WinUI.Controls.ImageCropper.csproj
+++ b/components/ImageCropper/src/CommunityToolkit.WinUI.Controls.ImageCropper.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>ImageCropper</ToolkitComponentName>
-    <Description>This package contains ImageCropper.</Description>
+    <Description>The ImageCropper control allows the user to freely crop an image.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.ImageCropperRns</RootNamespace>

--- a/components/LayoutTransformControl/samples/LayoutTransformControl.md
+++ b/components/LayoutTransformControl/samples/LayoutTransformControl.md
@@ -1,7 +1,7 @@
 ---
 title: LayoutTransformControl
 author: odonno
-description: The LayoutTransformControl is a control that support transformations on FrameworkElement as if applied by LayoutTransform.
+description: The LayoutTransformControl is a control that supports transformations on FrameworkElement as if applied by LayoutTransform.
 keywords: LayoutTransformControl, Control, Layout, RenderTransform, RotateTransform, ScaleTransform, SkewTransform, Transform
 dev_langs:
   - csharp

--- a/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
+++ b/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>LayoutTransformControl</ToolkitComponentName>
-    <Description>TThe LayoutTransformControl is a control that supports transformations on FrameworkElement as if applied by LayoutTransform.</Description>
+    <Description>The LayoutTransformControl is a control that supports transformations on FrameworkElement as if applied by LayoutTransform.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.LayoutTransformControlRns</RootNamespace>

--- a/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
+++ b/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>LayoutTransformControl</ToolkitComponentName>
-    <Description>This package contains LayoutTransformControl.</Description>
+    <Description>TThe LayoutTransformControl is a control that supports transformations on FrameworkElement as if applied by LayoutTransform.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.LayoutTransformControlRns</RootNamespace>

--- a/components/Media/src/CommunityToolkit.WinUI.Media.csproj
+++ b/components/Media/src/CommunityToolkit.WinUI.Media.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Media</ToolkitComponentName>
-    <Description>This package contains Media.</Description>
+    <Description>Create animated Media effects on UI elements. Saturation, Opacity, Color, CrossFade, Exposure, Sepia, HueRotation, and more.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.MediaRns</RootNamespace>

--- a/components/MetadataControl/src/CommunityToolkit.WinUI.Controls.MetadataControl.csproj
+++ b/components/MetadataControl/src/CommunityToolkit.WinUI.Controls.MetadataControl.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>MetadataControl</ToolkitComponentName>
-    <Description>This package contains MetadataControl.</Description>
+    <Description>The MetadataControl control displays a list of labels and hyper-links separated by a bullet.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.MetadataControlRns</RootNamespace>

--- a/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
+++ b/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Primitives</ToolkitComponentName>
-    <Description>This package contains Primitives.</Description>
+    <Description>Primitive layout controls such as SwitchPresenter, UniformGrid, WrapLayout, StaggeredPanel, WrapPanel, DockPanel, ConstrainedBox and more.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.PrimitivesRns</RootNamespace>

--- a/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
+++ b/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>RadialGauge</ToolkitComponentName>
-    <Description>This package contains RadialGauge.</Description>
+    <Description>The Radial Gauge Control displays a value in a certain range using a needle on a circular face.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.RadialGaugeRns</RootNamespace>

--- a/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
+++ b/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>RangeSelector</ToolkitComponentName>
-    <Description>This package contains RangeSelector.</Description>
+    <Description>A double Slider control that allows the user to select a sub-range of values from a larger range of values.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.RangeSelectorRns</RootNamespace>

--- a/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
+++ b/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>RichSuggestBox</ToolkitComponentName>
-    <Description>This package contains RichSuggestBox.</Description>
+    <Description>A rich text input control that auto-suggests and stores token items in a document.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.RichSuggestBoxRns</RootNamespace>

--- a/components/Segmented/src/CommunityToolkit.WinUI.Controls.Segmented.csproj
+++ b/components/Segmented/src/CommunityToolkit.WinUI.Controls.Segmented.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Segmented</ToolkitComponentName>
-    <Description>This package contains Segmented.</Description>
+    <Description>A common UI control to configure a view or setting.</Description>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.SegmentedRns</RootNamespace>

--- a/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
+++ b/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>SettingsControls</ToolkitComponentName>
-    <Description>This package contains SettingsControls.</Description>
+    <Description>Create a Windows 11 style settings experiences with these controls.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.SettingsControlsRns</RootNamespace>

--- a/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
+++ b/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Sizers</ToolkitComponentName>
-    <Description>This package contains SizerBase.</Description>
+    <Description>Resize various parts of your UI easily in a consistent fashion.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.SizersRns</RootNamespace>

--- a/components/TabbedCommandBar/src/CommunityToolkit.WinUI.Controls.TabbedCommandBar.csproj
+++ b/components/TabbedCommandBar/src/CommunityToolkit.WinUI.Controls.TabbedCommandBar.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras/3.0.23">
   <PropertyGroup>
     <ToolkitComponentName>TabbedCommandBar</ToolkitComponentName>
-    <Description>This package contains TabbedCommandBar.</Description>
+    <Description>Display multiple CommandBars in the same space using tabs, like Microsoft Office's ribbon.</Description>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.TabbedCommandBarRns</RootNamespace>

--- a/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
+++ b/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>TokenizingTextBox</ToolkitComponentName>
-    <Description>This package contains TokenizingTextBox.</Description>
+    <Description>A text input control that auto-suggests and displays token items.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.TokenizingTextBoxRns</RootNamespace>

--- a/components/Triggers/src/CommunityToolkit.WinUI.Triggers.csproj
+++ b/components/Triggers/src/CommunityToolkit.WinUI.Triggers.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <ToolkitComponentName>Triggers</ToolkitComponentName>
-    <Description>This package contains Triggers.</Description>
+    <Description>A collection of custom visual State Triggers.</Description>
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.TriggersRns</RootNamespace>


### PR DESCRIPTION
In preparation for 8.1, this PR replaces all default Nupkg descriptions. New descriptions were either:
- Pulled from other documentation (e.g. yaml front matter)
- In the case of components with many parts and docs, description is created by listing the features for the component, with the most used features listed first for discovery.