### PR TITLE
Package id as assembly name

### DIFF
--- a/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
+++ b/components/CameraPreview/src/CommunityToolkit.WinUI.Controls.CameraPreview.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="$(ToolkitHelpersSourceProject)"/>
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-   <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
+++ b/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
@@ -17,12 +17,15 @@
     <ProjectReference Include="$(ToolkitAnimationsSourceProject)" />
   </ItemGroup>
 
-  <!-- Sets this up as a toolkit component's source project -->
-  <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
 
   <PropertyGroup>
     <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
   </PropertyGroup>
+
+  <!-- Sets this up as a toolkit component's source project -->
+  <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
   <Target Name="BeforeGenerateProjectPriFile">
     <ItemGroup>

--- a/components/HeaderedControls/src/CommunityToolkit.WinUI.Controls.HeaderedControls.csproj
+++ b/components/HeaderedControls/src/CommunityToolkit.WinUI.Controls.HeaderedControls.csproj
@@ -10,6 +10,13 @@
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -19,8 +26,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/ImageCropper/src/CommunityToolkit.WinUI.Controls.ImageCropper.csproj
+++ b/components/ImageCropper/src/CommunityToolkit.WinUI.Controls.ImageCropper.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
+++ b/components/LayoutTransformControl/src/CommunityToolkit.WinUI.Controls.LayoutTransformControl.csproj
@@ -13,6 +13,13 @@
   <ItemGroup>
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
+
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
   
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
@@ -23,8 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/MetadataControl/src/CommunityToolkit.WinUI.Controls.MetadataControl.csproj
+++ b/components/MetadataControl/src/CommunityToolkit.WinUI.Controls.MetadataControl.csproj
@@ -10,6 +10,13 @@
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -19,8 +26,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-   <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
+++ b/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)"></ProjectReference>
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
+++ b/components/RadialGauge/src/CommunityToolkit.WinUI.Controls.RadialGauge.csproj
@@ -15,6 +15,13 @@
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -24,8 +31,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
+++ b/components/RangeSelector/src/CommunityToolkit.WinUI.Controls.RangeSelector.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
+++ b/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/Segmented/src/CommunityToolkit.WinUI.Controls.Segmented.csproj
+++ b/components/Segmented/src/CommunityToolkit.WinUI.Controls.Segmented.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
+++ b/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
@@ -10,6 +10,13 @@
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
   <ItemGroup>
     <ProjectReference Include="$(ToolkitTriggersSourceProject)"></ProjectReference>
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
+++ b/components/Sizers/src/CommunityToolkit.WinUI.Controls.Sizers.csproj
@@ -10,6 +10,13 @@
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -23,8 +30,4 @@
   <ItemGroup>
     <ProjectReference Include="$(ToolkitExtensionsSourceProject)" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/TabbedCommandBar/src/CommunityToolkit.WinUI.Controls.TabbedCommandBar.csproj
+++ b/components/TabbedCommandBar/src/CommunityToolkit.WinUI.Controls.TabbedCommandBar.csproj
@@ -7,10 +7,13 @@
     <RootNamespace>CommunityToolkit.WinUI.Controls.TabbedCommandBarRns</RootNamespace>
   </PropertyGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
-  
-  <PropertyGroup>
-      <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>

--- a/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
+++ b/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
@@ -16,6 +16,13 @@
     <ProjectReference Include="$(ToolkitPrimitivesSourceProject)" />    
   </ItemGroup>
 
+  <!-- Import PackageIdVariant for custom package id -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.TargetVersion.props" />
+
+   <PropertyGroup>
+    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
+  </PropertyGroup>
+
   <!-- Sets this up as a toolkit component's source project -->
   <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
 
@@ -25,8 +32,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
-   <PropertyGroup>
-    <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR updates our tooling to use the PackageId as the AssemblyName for components.

It required changes in both Tooling and any components with a custom PackageId due to the single-import. Hopefully this will get cleaner when we have nested components (https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/187).

Note that any components using a custom PackageId will need to be updated to define their `PackageId` _before_ importing `ToolkitComponent.SourceProject.props`, which requires importing the `PackageIdVariant` prop from `MultiTarget\WinUI.TargetVersion.props` first.

Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/188