### PR TITLE
Enable AoT for net8 in Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ (env.ENABLE_DIAGNOSTICS == 'true' || env.COREHOST_TRACE != '') && always() }}
         with:
-          name: build-logs
+          name: build-logs-${{ matrix.platform }} 
           path: ./**/*.*log
 
       - name: Artifact - ILC Repro

--- a/components/Collections/samples/IncrementalLoadingCollectionSample.xaml.cs
+++ b/components/Collections/samples/IncrementalLoadingCollectionSample.xaml.cs
@@ -17,7 +17,7 @@ public sealed partial class IncrementalLoadingCollectionSample : Page
     private void Load()
     {
         // IncrementalLoadingCollection can be bound to a GridView or a ListView. In this case it is a ListView called PeopleListView.
-        var collection = new IncrementalLoadingCollection<PeopleSource, Person>();
+        var collection = new IncrementalLoadingCollection<PeopleSource, Person>(new PeopleSource());
         PeopleListView.ItemsSource = collection;
 
         // Binds the collection to the page DataContext in order to use its IsLoading and HasMoreItems properties.

--- a/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -13,6 +13,9 @@ namespace CommunityToolkit.WinUI.Collections;
 /// <summary>
 /// A collection view implementation that supports filtering, sorting and incremental loading
 /// </summary>
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Item sorting uses reflection to get property types and may not be AOT compatible.")]
+#endif
 public partial class AdvancedCollectionView : IAdvancedCollectionView, INotifyPropertyChanged, ISupportIncrementalLoading, IComparer<object>
 {
     private readonly List<object> _view;

--- a/components/Collections/src/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
+++ b/components/Collections/src/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
@@ -134,7 +134,7 @@ public class IncrementalLoadingCollection<TSource, IType> : ObservableCollection
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This constructor is not AOT compatible and will be removed in a future version.")]
 #endif
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This constructor is not AOT compatible and will be removed in a future version.")]
+    [Obsolete("This constructor is not AOT compatible and will be removed in a future version. Use the other constructor and provide a source collection to use.")]
     public IncrementalLoadingCollection(int itemsPerPage = 20, Action onStartLoading = null, Action onEndLoading = null, Action<Exception> onError = null)
         : this(Activator.CreateInstance<TSource>(), itemsPerPage, onStartLoading, onEndLoading, onError)
     {

--- a/components/Collections/src/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
+++ b/components/Collections/src/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
@@ -130,6 +130,11 @@ public class IncrementalLoadingCollection<TSource, IType> : ObservableCollection
     /// An <see cref="Action"/> that is called if an error occurs during data retrieval.
     /// </param>
     /// <seealso cref="IIncrementalSource{TSource}"/>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This constructor is not AOT compatible and will be removed in a future version.")]
+#endif
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This constructor is not AOT compatible and will be removed in a future version.")]
     public IncrementalLoadingCollection(int itemsPerPage = 20, Action onStartLoading = null, Action onEndLoading = null, Action<Exception> onError = null)
         : this(Activator.CreateInstance<TSource>(), itemsPerPage, onStartLoading, onEndLoading, onError)
     {

--- a/components/Converters/src/TaskResultConverter.cs
+++ b/components/Converters/src/TaskResultConverter.cs
@@ -14,6 +14,9 @@ namespace CommunityToolkit.WinUI.Converters;
 /// The methods in this converter will safely return <see langword="null"/> if the input
 /// task is not set yet, still running, has faulted, or has been canceled.
 /// </summary>
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method uses reflection to try to access the Task<T>.Result property of the input Task instance.")]
+#endif
 public sealed class TaskResultConverter : IValueConverter
 {
     /// <inheritdoc/>

--- a/components/Extensions/src/Markup/EnumValuesExtension.cs
+++ b/components/Extensions/src/Markup/EnumValuesExtension.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.WinUI;
 /// A markup extension that returns a collection of values of a specific <see langword="enum"/>
 /// </summary>
 [MarkupExtensionReturnType(ReturnType = typeof(Array))]
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of a user-defined enum type at runtime.")]
+#endif
 public sealed class EnumValuesExtension : MarkupExtension
 {
     /// <summary>


### PR DESCRIPTION
Enables Native AoT functionality when running under .NET 8 in preparation for the WinAppSdk 1.6 release with NativeAoT support.  
 
Prerequisite PR: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/190