### PR TITLE
Fixed duplicated artifacts in CI when uploading package list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Download Package List
         uses: actions/download-artifact@v4
         with:
-          name: nuget-list
+          name: nuget-list-${{ matrix.platform }}
           path: ./
   
       - name: Download built packages for ${{ matrix.platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ env.IS_PR == 'false' }}
         with:
-          name: nuget-list
+          name: nuget-list-${{ matrix.platform }}
           if-no-files-found: error
           path: |
             ${{ github.workspace }}/.github/workflows/SignClientFileList.txt


### PR DESCRIPTION
This PR fixes an issue with the CI build on `main` when the "Upload Package List" step is run. See [this](https://github.com/CommunityToolkit/Windows/actions/runs/8903042347/job/24450102902) run for an example of the error. 

