### PR TITLE
Update Uno version, Uno TFMs to .NET 8

### DIFF
--- a/components/Animations/src/Extensions/CompositorExtensions.cs
+++ b/components/Animations/src/Extensions/CompositorExtensions.cs
@@ -109,7 +109,9 @@ public static class CompositorExtensions
             animation.InsertKeyFrame(0, from.Value);
         }
 
-        animation.Target = target;
+        if (target is not null)
+            animation.Target = target;
+        
         animation.Direction = direction;
         animation.IterationBehavior = iterationBehavior;
         animation.IterationCount = iterationCount;
@@ -170,7 +172,9 @@ public static class CompositorExtensions
             animation.InsertKeyFrame(0, from.Value);
         }
 
-        animation.Target = target;
+        if (target is not null)
+            animation.Target = target;
+            
         animation.Direction = direction;
         animation.IterationBehavior = iterationBehavior;
         animation.IterationCount = iterationCount;
@@ -231,7 +235,9 @@ public static class CompositorExtensions
             animation.InsertKeyFrame(0, from.Value);
         }
 
-        animation.Target = target;
+        if (target is not null)
+            animation.Target = target;
+
         animation.Direction = direction;
         animation.IterationBehavior = iterationBehavior;
         animation.IterationCount = iterationCount;
@@ -292,7 +298,9 @@ public static class CompositorExtensions
             animation.InsertKeyFrame(0, from.Value);
         }
 
-        animation.Target = target;
+        if (target is not null)
+            animation.Target = target;
+
         animation.Direction = direction;
         animation.IterationBehavior = iterationBehavior;
         animation.IterationCount = iterationCount;
@@ -353,7 +361,9 @@ public static class CompositorExtensions
             animation.InsertKeyFrame(0, from.Value);
         }
 
-        animation.Target = target;
+        if (target is not null)
+            animation.Target = target;
+
         animation.Direction = direction;
         animation.IterationBehavior = iterationBehavior;
         animation.IterationCount = iterationCount;
@@ -414,7 +424,9 @@ public static class CompositorExtensions
             animation.InsertKeyFrame(0, from.Value);
         }
 
-        animation.Target = target;
+        if (target is not null)
+            animation.Target = target;
+
         animation.Direction = direction;
         animation.IterationBehavior = iterationBehavior;
         animation.IterationCount = iterationCount;
@@ -475,7 +487,9 @@ public static class CompositorExtensions
             animation.InsertKeyFrame(0, from.Value);
         }
 
-        animation.Target = target;
+        if (target is not null)
+            animation.Target = target;
+
         animation.Direction = direction;
         animation.IterationBehavior = iterationBehavior;
         animation.IterationCount = iterationCount;

--- a/components/Extensions/src/Element/FrameworkElementExtensions.Mouse.cs
+++ b/components/Extensions/src/Element/FrameworkElementExtensions.Mouse.cs
@@ -101,6 +101,7 @@ public static partial class FrameworkElementExtensions
         CursorShape cursor = GetCursor((FrameworkElement)sender);
 
 #if !WINAPPSDK
+    if (Window.Current?.CoreWindow is not null)
         Window.Current.CoreWindow.PointerCursor = _cursors[cursor];
 #endif
     }
@@ -124,6 +125,7 @@ public static partial class FrameworkElementExtensions
         }
 
 #if !WINAPPSDK
+    if (Window.Current?.CoreWindow is not null)
         Window.Current.CoreWindow.PointerCursor = cursor;
 #endif
     }
@@ -138,6 +140,7 @@ public static partial class FrameworkElementExtensions
         // when the element is programatically unloaded, reset the cursor back to default
         // this is necessary when click triggers immediate change in layout and PointerExited is not called
 #if !WINAPPSDK
+    if (Window.Current?.CoreWindow is not null)
         Window.Current.CoreWindow.PointerCursor = _defaultCursor;
 #endif
     }

--- a/components/Helpers/src/ThemeListener.cs
+++ b/components/Helpers/src/ThemeListener.cs
@@ -76,7 +76,7 @@ public sealed class ThemeListener : IDisposable
 
         DispatcherQueue = dispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
 
-        if (Window.Current != null)
+        if (Window.Current?.CoreWindow is not null)
         {
             _accessible.HighContrastChanged += Accessible_HighContrastChanged;
             _settings.ColorValuesChanged += Settings_ColorValuesChanged;
@@ -163,7 +163,7 @@ public sealed class ThemeListener : IDisposable
     {
         _accessible.HighContrastChanged -= Accessible_HighContrastChanged;
         _settings.ColorValuesChanged -= Settings_ColorValuesChanged;
-        if (Window.Current != null)
+        if (Window.Current?.CoreWindow is not null)
         {
             Window.Current.CoreWindow.Activated -= CoreWindow_Activated;
         }


### PR DESCRIPTION
This PR:
- Updates our Uno packages to the latest stable version
- Updates the TFMs that Uno runs on from net7.0 to net8.0
- Fixes any issues that arise from the move to net8.0

Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/191