### PR TITLE
Removed usage of InternalsVisibleTo in all components

### DIFF
--- a/components/Animations/src/ArgumentNullExceptionExtensions.cs
+++ b/components/Animations/src/ArgumentNullExceptionExtensions.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+/// <summary>
+/// Throw helper extensions for <see cref="ArgumentNullException"/>.
+/// </summary>
+internal static class ArgumentNullExceptionExtensions
+{
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> for a given parameter name.
+    /// </summary>
+    /// <param name="_">Dummy value to invoke the extension upon (always pass <see langword="null"/>.</param>
+    /// <param name="parameterName">The name of the parameter to report in the exception.</param>
+    /// <exception cref="ArgumentNullException">Thrown with <paramref name="parameterName"/>.</exception>
+    [DoesNotReturn]
+    public static void Throw(this ArgumentNullException? _, string? parameterName)
+    {
+        throw new ArgumentNullException(parameterName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <see langword="null"/>.
+    /// </summary>
+    /// <param name="_">Dummy value to invoke the extension upon (always pass <see langword="null"/>.</param>
+    /// <param name="argument">The reference type argument to validate as non-<see langword="null"/>.</param>
+    /// <param name="parameterName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="argument"/> is <see langword="null"/>.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNull(this ArgumentNullException? _, [NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? parameterName = null)
+    {
+        if (argument is null)
+        {
+            Throw(parameterName);
+        }
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <see langword="null"/>.
+    /// </summary>
+    /// <param name="_">Dummy value to invoke the extension upon (always pass <see langword="null"/>.</param>
+    /// <param name="argument">The pointer argument to validate as non-<see langword="null"/>.</param>
+    /// <param name="parameterName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="argument"/> is <see langword="null"/>.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe void ThrowIfNull(this ArgumentNullException? _, [NotNull] void* argument, [CallerArgumentExpression(nameof(argument))] string? parameterName = null)
+    {
+        if (argument is null)
+        {
+            Throw(parameterName);
+        }
+    }
+
+    /// <inheritdoc cref="Throw(ArgumentNullException?, string?)"/>
+    [DoesNotReturn]
+    private static void Throw(string? parameterName)
+    {
+        throw new ArgumentNullException(parameterName);
+    }
+}

--- a/components/Animations/src/Builders/Interfaces/IKeyFrameInfo.cs
+++ b/components/Animations/src/Builders/Interfaces/IKeyFrameInfo.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations;
 /// <summary>
 /// An interface representing a generic model containing info for an abstract keyframe.
 /// </summary>
-internal interface IKeyFrameInfo
+public interface IKeyFrameInfo
 {
     /// <summary>
     /// Gets the easing type to use to reach the new keyframe.

--- a/components/Animations/src/Builders/NormalizedKeyFrameAnimationBuilder{T}.Composition.cs
+++ b/components/Animations/src/Builders/NormalizedKeyFrameAnimationBuilder{T}.Composition.cs
@@ -14,7 +14,7 @@ using Windows.UI;
 namespace CommunityToolkit.WinUI.Animations;
 
 /// <inheritdoc cref="NormalizedKeyFrameAnimationBuilder{T}"/>
-internal abstract partial class NormalizedKeyFrameAnimationBuilder<T>
+public abstract partial class NormalizedKeyFrameAnimationBuilder<T>
 {
     /// <summary>
     /// Gets a <see cref="CompositionAnimation"/> instance representing the animation to start.

--- a/components/Animations/src/Builders/NormalizedKeyFrameAnimationBuilder{T}.Xaml.cs
+++ b/components/Animations/src/Builders/NormalizedKeyFrameAnimationBuilder{T}.Xaml.cs
@@ -5,7 +5,7 @@
 namespace CommunityToolkit.WinUI.Animations;
 
 /// <inheritdoc cref="NormalizedKeyFrameAnimationBuilder{T}"/>
-internal abstract partial class NormalizedKeyFrameAnimationBuilder<T>
+public abstract partial class NormalizedKeyFrameAnimationBuilder<T>
     where T : unmanaged
 {
     /// <summary>

--- a/components/Animations/src/Builders/NormalizedKeyFrameAnimationBuilder{T}.cs
+++ b/components/Animations/src/Builders/NormalizedKeyFrameAnimationBuilder{T}.cs
@@ -17,7 +17,7 @@ namespace CommunityToolkit.WinUI.Animations;
 /// A generic keyframe animation builder.
 /// </summary>
 /// <typeparam name="T">The type of values being set by the animation being constructed.</typeparam>
-internal abstract partial class NormalizedKeyFrameAnimationBuilder<T> : INormalizedKeyFrameAnimationBuilder<T>
+public abstract partial class NormalizedKeyFrameAnimationBuilder<T> : INormalizedKeyFrameAnimationBuilder<T>
     where T : unmanaged
 {
     /// <summary>

--- a/components/Animations/src/CommunityToolkit.WinUI.Animations.csproj
+++ b/components/Animations/src/CommunityToolkit.WinUI.Animations.csproj
@@ -12,9 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="CommunityToolkit.WinUI.Media" />
-    <InternalsVisibleTo Include="CommunityToolkit.WinUI.Behaviors" />
-    
     <PackageReference Include="PolySharp" Version="1.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/components/Animations/src/Extensions/System/GuidExtensions.cs
+++ b/components/Animations/src/Extensions/System/GuidExtensions.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.WinUI.Animations;
 /// <summary>
 /// An extension <see langword="class"/> for the <see cref="Guid"/> type
 /// </summary>
-internal static class GuidExtensions
+public static class GuidExtensions
 {
     /// <summary>
     /// Returns a <see cref="string"/> representation of a <see cref="Guid"/> only made of uppercase letters

--- a/components/Animations/src/Xaml/AnimationSet.cs
+++ b/components/Animations/src/Xaml/AnimationSet.cs
@@ -57,7 +57,7 @@ public sealed class AnimationSet : DependencyObjectCollection
     /// <summary>
     /// Gets or sets the weak reference to the parent that owns the current animation collection.
     /// </summary>
-    internal WeakReference<UIElement>? ParentReference { get; set; }
+    public WeakReference<UIElement>? ParentReference { get; set; }
 
     /// <inheritdoc cref="AnimationBuilder.Start(UIElement)"/>
     /// <exception cref="InvalidOperationException">Thrown when there is no attached <see cref="UIElement"/> instance.</exception>

--- a/components/Extensions/src/CommunityToolkit.WinUI.Extensions.csproj
+++ b/components/Extensions/src/CommunityToolkit.WinUI.Extensions.csproj
@@ -28,10 +28,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-
-    <!-- TODO: We should figure out a better way to share internal helpers without duplication -->
-    <!-- e.g. Animations is using ThrowIfNull helper... -->
-    <InternalsVisibleTo Include="CommunityToolkit.WinUI.Animations" />
-    <InternalsVisibleTo Include="CommunityToolkit.WinUI.Media" />
   </ItemGroup>
 </Project>

--- a/components/Extensions/src/Shadows/AttachedDropShadow.cs
+++ b/components/Extensions/src/Shadows/AttachedDropShadow.cs
@@ -31,7 +31,7 @@ public sealed class AttachedDropShadow : AttachedShadowBase
 #endif
 
     /// <inheritdoc/>
-    protected internal override bool SupportsOnSizeChangedEvent => true;
+    public override bool SupportsOnSizeChangedEvent => true;
 
     private static readonly TypedResourceKey<CompositionRoundedRectangleGeometry> RoundedRectangleGeometryResourceKey = "RoundedGeometry";
     private static readonly TypedResourceKey<CompositionSpriteShape> ShapeResourceKey = "Shape";
@@ -350,7 +350,7 @@ public sealed class AttachedDropShadow : AttachedShadowBase
     }
 
     /// <inheritdoc/>
-    protected internal override void OnSizeChanged(AttachedShadowElementContext context, Size newSize, Size previousSize)
+    public override void OnSizeChanged(AttachedShadowElementContext context, Size newSize, Size previousSize)
     {
         if (context.SpriteVisual != null)
         {

--- a/components/Extensions/src/Shadows/AttachedShadowBase.cs
+++ b/components/Extensions/src/Shadows/AttachedShadowBase.cs
@@ -101,7 +101,7 @@ public abstract partial class AttachedShadowBase : DependencyObject, IAttachedSh
     /// <summary>
     /// Gets a value indicating whether or not OnSizeChanged should be called when <see cref="FrameworkElement.SizeChanged"/> is fired.
     /// </summary>
-    protected internal abstract bool SupportsOnSizeChangedEvent { get; }
+    public abstract bool SupportsOnSizeChangedEvent { get; }
 
     /// <summary>
     /// Use this method as the <see cref="PropertyChangedCallback"/> for <see cref="DependencyProperty">DependencyProperties</see> in derived classes.
@@ -142,7 +142,7 @@ public abstract partial class AttachedShadowBase : DependencyObject, IAttachedSh
     /// Override to handle when the <see cref="AttachedShadowElementContext"/> for an element is being initialized.
     /// </summary>
     /// <param name="context">The <see cref="AttachedShadowElementContext"/> that is being initialized.</param>
-    protected internal virtual void OnElementContextInitialized(AttachedShadowElementContext context)
+    public virtual void OnElementContextInitialized(AttachedShadowElementContext context)
     {
         OnPropertyChanged(context, OpacityProperty, Opacity, Opacity);
         OnPropertyChanged(context, BlurRadiusProperty, BlurRadius, BlurRadius);
@@ -288,7 +288,7 @@ public abstract partial class AttachedShadowBase : DependencyObject, IAttachedSh
     /// <param name="context">The <see cref="AttachedShadowElementContext"/> for the <see cref="FrameworkElement"/> firing its SizeChanged event</param>
     /// <param name="newSize">The new size of the <see cref="FrameworkElement"/></param>
     /// <param name="previousSize">The previous size of the <see cref="FrameworkElement"/></param>
-    protected internal virtual void OnSizeChanged(AttachedShadowElementContext context, Size newSize, Size previousSize)
+    public virtual void OnSizeChanged(AttachedShadowElementContext context, Size newSize, Size previousSize)
     {
     }
 }

--- a/components/Extensions/src/Shadows/AttachedShadowElementContext.cs
+++ b/components/Extensions/src/Shadows/AttachedShadowElementContext.cs
@@ -278,7 +278,7 @@ public sealed class AttachedShadowElementContext
     /// </summary>
     /// <typeparam name="T">The type of the resource being added.</typeparam>
     /// <returns>The resource that was added</returns>
-    internal T AddResource<T>(TypedResourceKey<T> key, T resource)
+    public T AddResource<T>(TypedResourceKey<T> key, T resource)
         where T : notnull => AddResource(key.Key, resource);
 
     /// <summary>
@@ -286,28 +286,28 @@ public sealed class AttachedShadowElementContext
     /// </summary>
     /// <typeparam name="T">The type of the resource being retrieved.</typeparam>
     /// <returns>True if the resource exists, false otherwise</returns>
-    internal bool TryGetResource<T>(TypedResourceKey<T> key, out T? resource) => TryGetResource(key.Key, out resource);
+    public bool TryGetResource<T>(TypedResourceKey<T> key, out T? resource) => TryGetResource(key.Key, out resource);
 
     /// <summary>
     /// Retries a resource with the specified key and type
     /// </summary>
     /// <typeparam name="T">The type of the resource being retrieved.</typeparam>
     /// <returns>The resource if it exists or a default value.</returns>
-    internal T? GetResource<T>(TypedResourceKey<T> key) => GetResource<T>(key.Key);
+    public T? GetResource<T>(TypedResourceKey<T> key) => GetResource<T>(key.Key);
 
     /// <summary>
     /// Removes an existing resource with the specified key and type
     /// </summary>
     /// <typeparam name="T">The type of the resource being removed.</typeparam>
     /// <returns>The resource that was removed, if any</returns>
-    internal T? RemoveResource<T>(TypedResourceKey<T> key) => RemoveResource<T>(key.Key);
+    public T? RemoveResource<T>(TypedResourceKey<T> key) => RemoveResource<T>(key.Key);
 
     /// <summary>
     /// Removes an existing resource with the specified key and type, and <see cref="IDisposable.Dispose">disposes</see> it
     /// </summary>
     /// <typeparam name="T">The type of the resource being removed.</typeparam>
     /// <returns>The resource that was removed, if any</returns>
-    internal T? RemoveAndDisposeResource<T>(TypedResourceKey<T> key)
+    public T? RemoveAndDisposeResource<T>(TypedResourceKey<T> key)
         where T : IDisposable => RemoveAndDisposeResource<T>(key.Key);
 
     /// <summary>

--- a/components/Extensions/src/Shadows/TypedResourceKey.cs
+++ b/components/Extensions/src/Shadows/TypedResourceKey.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.WinUI;
 /// A generic class that can be used to retrieve keyed resources of the specified type.
 /// </summary>
 /// <typeparam name="TValue">The <see cref="Type"/> of resource the <see cref="TypedResourceKey{TValue}"/> will retrieve.</typeparam>
-internal sealed class TypedResourceKey<TValue>
+public sealed class TypedResourceKey<TValue>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="TypedResourceKey{TValue}"/> class  with the specified key.

--- a/components/Media/src/ArgumentNullExceptionExtensions.cs
+++ b/components/Media/src/ArgumentNullExceptionExtensions.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+/// <summary>
+/// Throw helper extensions for <see cref="ArgumentNullException"/>.
+/// </summary>
+internal static class ArgumentNullExceptionExtensions
+{
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> for a given parameter name.
+    /// </summary>
+    /// <param name="_">Dummy value to invoke the extension upon (always pass <see langword="null"/>.</param>
+    /// <param name="parameterName">The name of the parameter to report in the exception.</param>
+    /// <exception cref="ArgumentNullException">Thrown with <paramref name="parameterName"/>.</exception>
+    [DoesNotReturn]
+    public static void Throw(this ArgumentNullException? _, string? parameterName)
+    {
+        throw new ArgumentNullException(parameterName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <see langword="null"/>.
+    /// </summary>
+    /// <param name="_">Dummy value to invoke the extension upon (always pass <see langword="null"/>.</param>
+    /// <param name="argument">The reference type argument to validate as non-<see langword="null"/>.</param>
+    /// <param name="parameterName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="argument"/> is <see langword="null"/>.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNull(this ArgumentNullException? _, [NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? parameterName = null)
+    {
+        if (argument is null)
+        {
+            Throw(parameterName);
+        }
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <see langword="null"/>.
+    /// </summary>
+    /// <param name="_">Dummy value to invoke the extension upon (always pass <see langword="null"/>.</param>
+    /// <param name="argument">The pointer argument to validate as non-<see langword="null"/>.</param>
+    /// <param name="parameterName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="argument"/> is <see langword="null"/>.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe void ThrowIfNull(this ArgumentNullException? _, [NotNull] void* argument, [CallerArgumentExpression(nameof(argument))] string? parameterName = null)
+    {
+        if (argument is null)
+        {
+            Throw(parameterName);
+        }
+    }
+
+    /// <inheritdoc cref="Throw(ArgumentNullException?, string?)"/>
+    [DoesNotReturn]
+    private static void Throw(string? parameterName)
+    {
+        throw new ArgumentNullException(parameterName);
+    }
+}

--- a/components/Media/src/CommunityToolkit.WinUI.Media.csproj
+++ b/components/Media/src/CommunityToolkit.WinUI.Media.csproj
@@ -7,6 +7,7 @@
     
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.MediaRns</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/components/Media/src/Shadows/AttachedCardShadow.cs
+++ b/components/Media/src/Shadows/AttachedCardShadow.cs
@@ -88,10 +88,10 @@ public sealed class AttachedCardShadow : AttachedShadowBase
 #endif
 
     /// <inheritdoc/>
-    protected internal override bool SupportsOnSizeChangedEvent => true;
+    public override bool SupportsOnSizeChangedEvent => true;
 
     /// <inheritdoc/>
-    protected internal override void OnElementContextInitialized(AttachedShadowElementContext context)
+    public override void OnElementContextInitialized(AttachedShadowElementContext context)
     {
         UpdateVisualOpacityMask(context);
         base.OnElementContextInitialized(context);
@@ -330,7 +330,7 @@ public sealed class AttachedCardShadow : AttachedShadowBase
     }
 
     /// <inheritdoc />
-    protected internal override void OnSizeChanged(AttachedShadowElementContext context, Size newSize, Size previousSize)
+    public override void OnSizeChanged(AttachedShadowElementContext context, Size newSize, Size previousSize)
     {
         Vector2 sizeAsVec2 = newSize.ToVector2();
 


### PR DESCRIPTION
This PR:
1. Removes all usage of `InternalsVisibleTo` in components in this repo, closes #441.
2. Copies minor helpers such as `ArgumentNullExceptionExtensions`, keeping them internal.
3. Makes public any internal code required to build, mostly around Animations references in Media and Extensions references in Animations.

For 3), it's worth noting that several API surfaces were marked as public which were previously internal. _Only_ the areas that needed to be exposed for other toolkit packages to build on top were updated. 

These changes were required to be extended by other components in the toolkit. I'm in favor of publishing them as public for others to build on to the same extent we have, unless someone we have information on why these were originally made internal and good reason to keep it. 

