### PR TITLE
Update _toolTip even if toolTipText isn't available

### DIFF
--- a/components/RangeSelector/src/RangeSelector.Input.Drag.cs
+++ b/components/RangeSelector/src/RangeSelector.Input.Drag.cs
@@ -77,7 +77,7 @@ public partial class RangeSelector : Control
 
         Canvas.SetLeft(thumb, nextPos);
 
-        if (_toolTipText != null && _toolTip != null && thumb != null)
+        if (_toolTip != null && thumb != null)
         {
             var thumbCenter = nextPos + (thumb.Width / 2);
             _toolTip.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
@@ -99,7 +99,7 @@ public partial class RangeSelector : Control
         Canvas.SetZIndex(otherThumb, 0);
         _oldValue = RangeStart;
 
-        if (_toolTipText != null && _toolTip != null)
+        if (_toolTip != null)
         {
             _toolTip.Visibility = Visibility.Visible;
             var thumbCenter = _absolutePosition + (thumb.Width / 2);
@@ -107,7 +107,8 @@ public partial class RangeSelector : Control
             var ttWidth = _toolTip.ActualWidth / 2;
             Canvas.SetLeft(_toolTip, thumbCenter - ttWidth);
 
-            UpdateToolTipText(this, _toolTipText, useMin ? RangeStart : RangeEnd);
+            if (_toolTipText != null)
+                UpdateToolTipText(this, _toolTipText, useMin ? RangeStart : RangeEnd);
         }
 
         VisualStateManager.GoToState(this, useMin ? MinPressedState : MaxPressedState, true);


### PR DESCRIPTION
## Fixes

Allows adding custom content to the tooltip.
The problem with replacing the tooltipText is that the tooltip completely stops working. I want the container to still work and get placed. The code was doing an unnecessary null check on an object that wasn't being used.


## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

- Bugfix 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Override the style in a subclass that replaces tooltipText with something else makes tooltip stop working.

## What is the new behavior?

Presence of the ToolTipText textblock is no longer required.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [x] Header has been added to all new source files
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
