### PR TITLE
Enable 'AcrylicBrush' in WinUI 3 again

### DIFF
--- a/components/Media/src/Brushes/AcrylicBrush.cs
+++ b/components/Media/src/Brushes/AcrylicBrush.cs
@@ -2,17 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if WINUI2
 using CommunityToolkit.WinUI.Media.Pipelines;
+#if WINUI3
+using Microsoft.UI.Composition;
+#endif
 using Windows.UI;
+#if WINUI2
 using Windows.UI.Composition;
+#endif
 
 namespace CommunityToolkit.WinUI.Media;
 
 /// <summary>
 /// A <see cref="XamlCompositionBrush"/> that implements an acrylic effect with customizable parameters
 /// </summary>
-public sealed class AcrylicBrush : XamlCompositionEffectBrushBase
+public sealed partial class AcrylicBrush : XamlCompositionEffectBrushBase
 {
     /// <summary>
     /// The <see cref="EffectSetter{T}"/> instance in use to set the blur amount
@@ -30,6 +34,7 @@ public sealed class AcrylicBrush : XamlCompositionEffectBrushBase
     /// </summary>
     private EffectSetter<float>? tintOpacitySetter;
 
+#if WINUI2
     /// <summary>
     /// Gets or sets the background source mode for the effect (the default is <see cref="AcrylicBackgroundSource.Backdrop"/>).
     /// </summary>
@@ -62,6 +67,7 @@ public sealed class AcrylicBrush : XamlCompositionEffectBrushBase
             brush.OnConnected();
         }
     }
+#endif
 
     /// <summary>
     /// Gets or sets the blur amount for the effect (must be a positive value)
@@ -90,7 +96,9 @@ public sealed class AcrylicBrush : XamlCompositionEffectBrushBase
     private static void OnBlurAmountPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is AcrylicBrush brush &&
+#if WINUI2
             brush.BackgroundSource != AcrylicBackgroundSource.HostBackdrop && // Blur is fixed by OS when using HostBackdrop source.
+#endif
             brush.CompositionBrush is CompositionBrush target)
         {
             brush.blurAmountSetter?.Invoke(target, (float)(double)e.NewValue);
@@ -197,6 +205,7 @@ public sealed class AcrylicBrush : XamlCompositionEffectBrushBase
     /// <inheritdoc/>
     protected override PipelineBuilder OnPipelineRequested()
     {
+#if WINUI2
         switch (BackgroundSource)
         {
             case AcrylicBackgroundSource.Backdrop:
@@ -217,6 +226,15 @@ public sealed class AcrylicBrush : XamlCompositionEffectBrushBase
                     TextureUri);
             default: throw new ArgumentOutOfRangeException(nameof(BackgroundSource), $"Invalid acrylic source: {BackgroundSource}");
         }
+#else
+        return PipelineBuilder.FromBackdropAcrylic(
+            TintColor,
+            out this.tintColorSetter,
+            (float)TintOpacity,
+            out this.tintOpacitySetter,
+            (float)BlurAmount,
+            out blurAmountSetter,
+            TextureUri);
+#endif
     }
 }
-#endif

--- a/components/Media/src/Brushes/AcrylicBrush.cs
+++ b/components/Media/src/Brushes/AcrylicBrush.cs
@@ -69,10 +69,16 @@ public sealed partial class AcrylicBrush : XamlCompositionEffectBrushBase
     }
 #endif
 
+#if WINUI2
     /// <summary>
     /// Gets or sets the blur amount for the effect (must be a positive value)
     /// </summary>
     /// <remarks>This property is ignored when the active mode is <see cref="AcrylicBackgroundSource.HostBackdrop"/></remarks>
+#else
+    /// <summary>
+    /// Gets or sets the blur amount for the effect (must be a positive value)
+    /// </summary>
+#endif
     public double BlurAmount
     {
         get => (double)GetValue(BlurAmountProperty);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

This PR adds `AcrylicBrush` on WinUI 3 again. On this target, the `BackgroundSource` property has been removed.

## What is the current behavior?

This type is missing for WinUI 3.

## What is the new behavior?

The type is usable again.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [ ] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [X] Header has been added to all new source files
- [X] Contains **NO** breaking changes