### PR TITLE
Exclude uap in WinUI package, wasdk in UWP package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,12 +261,12 @@ jobs:
         with:
           vs-version: '[17.9,)'
 
-      - name: Define excluded MultiTargets (WinUI ${{ matrix.winui }})
+      - name: Define excluded MultiTargets (WinUI 2)
         if: ${{ matrix.winui == '2' }}
         run: |
           echo "EXCLUDED_MULTITARGETS=wasdk" >> $env:GITHUB_ENV
 
-      - name: Define excluded MultiTargets (WinUI ${{ matrix.winui }})
+      - name: Define excluded MultiTargets (WinUI 3)
         if: ${{ matrix.winui == '3' }}
         run: |
           echo "EXCLUDED_MULTITARGETS=uwp" >> $env:GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.ref }}
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools
@@ -106,7 +105,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.ref }}
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools
@@ -229,7 +227,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.ref }}
 
       # Semver regex: https://regex101.com/r/Ly7O1x/3/
       - name: Format Date/Time of Release Package Version
@@ -428,7 +425,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.ref }}
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.ref }}
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools
@@ -105,6 +106,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.ref }}
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools
@@ -227,6 +229,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.ref }}
 
       # Semver regex: https://regex101.com/r/Ly7O1x/3/
       - name: Format Date/Time of Release Package Version
@@ -425,6 +428,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.ref }}
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,9 +261,19 @@ jobs:
         with:
           vs-version: '[17.9,)'
 
+      - name: Define excluded MultiTargets (WinUI ${{ matrix.winui }})
+        if: ${{ matrix.winui == '2' }}
+        run: |
+          echo "EXCLUDED_MULTITARGETS=wasdk" >> $env:GITHUB_ENV
+
+      - name: Define excluded MultiTargets (WinUI ${{ matrix.winui }})
+        if: ${{ matrix.winui == '3' }}
+        run: |
+          echo "EXCLUDED_MULTITARGETS=uwp" >> $env:GITHUB_ENV
+
       # Build and pack component nupkg
       - name: Build and pack component packages
-        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludedMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
 
       # Push Pull Request Packages to our DevOps Artifacts Feed (see nuget.config)
       - name: Push Pull Request Packages (if not fork)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
 
       # Build and pack component nupkg
       - name: Build and pack component packages
-        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludedMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
 
       # Push Pull Request Packages to our DevOps Artifacts Feed (see nuget.config)
       - name: Push Pull Request Packages (if not fork)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [ main, 'rel/*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'dev/*' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This PR fixes an issue with our CI where the built UWP and WinUI packages included "All" multitargets. 

Including both doesn't cause issues in UWP or WinUI projects normally as the correct TFM is picked up. However, in certain scenarios uap may be picked up when the winappsdk TFMs were intended, such as in the packaging project for applications using the Windows Application Packaging setup. 

Closes https://github.com/CommunityToolkit/Windows/issues/490#issuecomment-2332805012