### PR TITLE
Fix analyzer warnings for CsWinRTAotWarningLevel 2

### DIFF
--- a/components/Animations/src/Expressions/ExpressionNodes/BooleanNode.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/BooleanNode.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class BooleanNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class BooleanNode : ExpressionNode
+public sealed partial class BooleanNode : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BooleanNode"/> class.

--- a/components/Animations/src/Expressions/ExpressionNodes/ColorNode.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/ColorNode.cs
@@ -12,7 +12,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class ColorNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class ColorNode : ExpressionNode
+public sealed partial class ColorNode : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ColorNode"/> class.

--- a/components/Animations/src/Expressions/ExpressionNodes/Matrix3x2Node.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/Matrix3x2Node.cs
@@ -13,7 +13,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class Matrix3x2Node. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class Matrix3x2Node : ExpressionNode
+public sealed partial class Matrix3x2Node : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Matrix3x2Node"/> class.

--- a/components/Animations/src/Expressions/ExpressionNodes/QuaternionNode.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/QuaternionNode.cs
@@ -12,7 +12,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class QuaternionNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref=CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class QuaternionNode : ExpressionNode
+public sealed partial class QuaternionNode : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="QuaternionNode"/> class.

--- a/components/Animations/src/Expressions/ExpressionNodes/ScalarNode.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/ScalarNode.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class ScalarNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class ScalarNode : ExpressionNode
+public sealed partial class ScalarNode : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ScalarNode"/> class.

--- a/components/Animations/src/Expressions/ExpressionNodes/Vector2Node.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/Vector2Node.cs
@@ -12,7 +12,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class Vector2Node. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class Vector2Node : ExpressionNode
+public sealed partial class Vector2Node : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Vector2Node"/> class.

--- a/components/Animations/src/Expressions/ExpressionNodes/Vector3Node.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/Vector3Node.cs
@@ -12,7 +12,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class Vector3Node. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class Vector3Node : ExpressionNode
+public sealed partial class Vector3Node : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Vector3Node"/> class.

--- a/components/Animations/src/Expressions/ExpressionNodes/Vector4Node.cs
+++ b/components/Animations/src/Expressions/ExpressionNodes/Vector4Node.cs
@@ -12,7 +12,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class Vector4Node. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ExpressionNode" />
-public sealed class Vector4Node : ExpressionNode
+public sealed partial class Vector4Node : ExpressionNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Vector4Node"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/AmbientLightReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/AmbientLightReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class AmbientLightReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="ReferenceNode" />
-public sealed class AmbientLightReferenceNode : ReferenceNode
+public sealed partial class AmbientLightReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AmbientLightReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/ColorBrushReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/ColorBrushReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class ColorBrushReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class ColorBrushReferenceNode : ReferenceNode
+public sealed partial class ColorBrushReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ColorBrushReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/DistantLightReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/DistantLightReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class DistantLightReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class DistantLightReferenceNode : ReferenceNode
+public sealed partial class DistantLightReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DistantLightReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/DropShadowReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/DropShadowReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class DropShadowReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class DropShadowReferenceNode : ReferenceNode
+public sealed partial class DropShadowReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DropShadowReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/InsetClipReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/InsetClipReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class InsetClipReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class InsetClipReferenceNode : ReferenceNode
+public sealed partial class InsetClipReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="InsetClipReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/InteractionTrackerReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/InteractionTrackerReferenceNode.cs
@@ -16,7 +16,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class InteractionTrackerReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class InteractionTrackerReferenceNode : ReferenceNode
+public sealed partial class InteractionTrackerReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="InteractionTrackerReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/ManipulationPropertySetReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/ManipulationPropertySetReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class ManipulationPropertySetReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.PropertySetReferenceNode" />
-public sealed class ManipulationPropertySetReferenceNode : PropertySetReferenceNode
+public sealed partial class ManipulationPropertySetReferenceNode : PropertySetReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ManipulationPropertySetReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/NineGridBrushReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/NineGridBrushReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class NineGridBrushReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class NineGridBrushReferenceNode : ReferenceNode
+public sealed partial class NineGridBrushReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="NineGridBrushReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/PointLightReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/PointLightReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class PointLightReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class PointLightReferenceNode : ReferenceNode
+public sealed partial class PointLightReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="PointLightReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/PointerPositionPropertySetReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/PointerPositionPropertySetReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class PointerPositionPropertySetReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.PropertySetReferenceNode" />
-public sealed class PointerPositionPropertySetReferenceNode : PropertySetReferenceNode
+public sealed partial class PointerPositionPropertySetReferenceNode : PropertySetReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="PointerPositionPropertySetReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/PropertySetReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/PropertySetReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class PropertySetReferenceNode.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public class PropertySetReferenceNode : ReferenceNode
+public partial class PropertySetReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="PropertySetReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/SpotLightReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/SpotLightReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class SpotLightReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class SpotLightReferenceNode : ReferenceNode
+public sealed partial class SpotLightReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SpotLightReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/SurfaceBrushReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/SurfaceBrushReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class SurfaceBrushReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class SurfaceBrushReferenceNode : ReferenceNode
+public sealed partial class SurfaceBrushReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SurfaceBrushReferenceNode"/> class.

--- a/components/Animations/src/Expressions/ReferenceNodes/VisualReferenceNode.cs
+++ b/components/Animations/src/Expressions/ReferenceNodes/VisualReferenceNode.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Animations.Expressions;
 /// Class VisualReferenceNode. This class cannot be inherited.
 /// </summary>
 /// <seealso cref="CommunityToolkit.WinUI.Animations.Expressions.ReferenceNode" />
-public sealed class VisualReferenceNode : ReferenceNode
+public sealed partial class VisualReferenceNode : ReferenceNode
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="VisualReferenceNode" /> class.

--- a/components/Behaviors/src/FocusTargetList.cs
+++ b/components/Behaviors/src/FocusTargetList.cs
@@ -7,6 +7,6 @@ namespace CommunityToolkit.WinUI.Behaviors;
 /// <summary>
 /// A collection of <see cref="FocusTarget"/>.
 /// </summary>
-public sealed class FocusTargetList : List<FocusTarget>
+public sealed partial class FocusTargetList : List<FocusTarget>
 {
 }

--- a/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.Defer.cs
+++ b/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.Defer.cs
@@ -22,7 +22,7 @@ public partial class AdvancedCollectionView
     /// Notification deferrer helper class
     /// </summary>
 #pragma warning disable CA1063 // Implement IDisposable Correctly
-    public class NotificationDeferrer : IDisposable
+    public partial class NotificationDeferrer : IDisposable
 #pragma warning restore CA1063 // Implement IDisposable Correctly
     {
         private readonly AdvancedCollectionView _acvs;

--- a/components/Helpers/src/CameraHelper/CameraHelper.cs
+++ b/components/Helpers/src/CameraHelper/CameraHelper.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Helpers;
 /// Make sure you have the capability webcam enabled for your app to access the device's camera.
 /// </summary>
 #pragma warning disable CA1063 // Implement IDisposable Correctly
-public class CameraHelper : IDisposable
+public partial class CameraHelper : IDisposable
 {
     private static IReadOnlyList<MediaFrameSourceGroup>? _frameSourceGroups;
 #pragma warning disable CA2213 // Disposable fields should be disposed

--- a/components/Helpers/src/ThemeListener.cs
+++ b/components/Helpers/src/ThemeListener.cs
@@ -26,7 +26,7 @@ public delegate void ThemeChangedEvent(ThemeListener sender);
 /// and Signals an Event when they occur.
 /// </summary>
 [AllowForWeb]
-public sealed class ThemeListener : IDisposable
+public sealed partial class ThemeListener : IDisposable
 {
     /// <summary>
     /// Gets the Name of the Current Theme.

--- a/components/Media/src/Extensions/System.Threading.Tasks/AsyncMutex.cs
+++ b/components/Media/src/Extensions/System.Threading.Tasks/AsyncMutex.cs
@@ -10,7 +10,9 @@ namespace CommunityToolkit.WinUI.Media;
 /// An <see langword="async"/> <see cref="AsyncMutex"/> implementation that can be easily used inside a <see langword="using"/> block
 /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
+#pragma warning disable CsWinRT1028 // Partial not required for types never passed to native WinRT method.
 internal sealed class AsyncMutex
+#pragma warning restore CsWinRT1028
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
 {
     /// <summary>
@@ -32,7 +34,9 @@ internal sealed class AsyncMutex
     /// <summary>
     /// Private class that implements the automatic release of the semaphore
     /// </summary>
+#pragma warning disable CsWinRT1028 // Partial not required for types never passed to native WinRT method.
     private sealed class Lock : IDisposable
+#pragma warning restore CsWinRT1028
     {
         /// <summary>
         /// The <see cref="SemaphoreSlim"/> instance of the parent class

--- a/components/Media/src/Extensions/System.Threading.Tasks/AsyncMutex.cs
+++ b/components/Media/src/Extensions/System.Threading.Tasks/AsyncMutex.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.WinUI.Media;
 /// An <see langword="async"/> <see cref="AsyncMutex"/> implementation that can be easily used inside a <see langword="using"/> block
 /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
-internal sealed partial class AsyncMutex
+internal sealed class AsyncMutex
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
 {
     /// <summary>
@@ -32,7 +32,7 @@ internal sealed partial class AsyncMutex
     /// <summary>
     /// Private class that implements the automatic release of the semaphore
     /// </summary>
-    private sealed partial class Lock : IDisposable
+    private sealed class Lock : IDisposable
     {
         /// <summary>
         /// The <see cref="SemaphoreSlim"/> instance of the parent class

--- a/components/Media/src/Extensions/System.Threading.Tasks/AsyncMutex.cs
+++ b/components/Media/src/Extensions/System.Threading.Tasks/AsyncMutex.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.WinUI.Media;
 /// An <see langword="async"/> <see cref="AsyncMutex"/> implementation that can be easily used inside a <see langword="using"/> block
 /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
-internal sealed class AsyncMutex
+internal sealed partial class AsyncMutex
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
 {
     /// <summary>
@@ -32,7 +32,7 @@ internal sealed class AsyncMutex
     /// <summary>
     /// Private class that implements the automatic release of the semaphore
     /// </summary>
-    private sealed class Lock : IDisposable
+    private sealed partial class Lock : IDisposable
     {
         /// <summary>
         /// The <see cref="SemaphoreSlim"/> instance of the parent class

--- a/components/Primitives/src/StaggeredLayout/StaggeredColumnLayout.cs
+++ b/components/Primitives/src/StaggeredLayout/StaggeredColumnLayout.cs
@@ -5,7 +5,7 @@
 namespace CommunityToolkit.WinUI.Controls;
 
 [DebuggerDisplay("Count = {Count}, Height = {Height}")]
-internal class StaggeredColumnLayout : List<StaggeredItem>
+internal partial class StaggeredColumnLayout : List<StaggeredItem>
 {
     public double Height { get; private set; }
 

--- a/components/RichSuggestBox/src/RichSuggestToken.cs
+++ b/components/RichSuggestBox/src/RichSuggestToken.cs
@@ -13,7 +13,7 @@ namespace CommunityToolkit.WinUI.Controls;
 /// <summary>
 /// RichSuggestToken describes a suggestion token in the document.
 /// </summary>
-public class RichSuggestToken : INotifyPropertyChanged
+public partial class RichSuggestToken : INotifyPropertyChanged
 {
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/components/SettingsControls/src/Helpers/StyleExtensions.cs
+++ b/components/SettingsControls/src/Helpers/StyleExtensions.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.WinUI.Controls;
 public static partial class StyleExtensions
 {
     // Used to distinct normal ResourceDictionary and the one we add.
-    private sealed class StyleExtensionResourceDictionary : ResourceDictionary
+    private sealed partial class StyleExtensionResourceDictionary : ResourceDictionary
     {
     }
 

--- a/components/TokenizingTextBox/src/InterspersedObservableCollection.cs
+++ b/components/TokenizingTextBox/src/InterspersedObservableCollection.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Controls;
 #pragma warning disable CS8622
 #pragma warning disable CS8603
 #pragma warning disable CS8714
-internal class InterspersedObservableCollection : IList, IEnumerable<object>, INotifyCollectionChanged
+internal partial class InterspersedObservableCollection : IList, IEnumerable<object>, INotifyCollectionChanged
 {
     public IList ItemsSource { get; private set; }
 


### PR DESCRIPTION
- Enables additional AoT analyzers by setting `CsWinRTAotWarningLevel` to 2, as suggested in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/195#discussion_r1722185832.
- Resolves and fixes new analyzer warnings/errors in code

Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/212