### PR TITLE
Fixed AoT data binding in IncrementalLoadingCollectionSample

### DIFF
--- a/components/Collections/samples/IncrementalLoadingCollectionSample.xaml
+++ b/components/Collections/samples/IncrementalLoadingCollectionSample.xaml
@@ -1,9 +1,9 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="CollectionsExperiment.Samples.IncrementalLoadingCollectionSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:local="using:IncrementalLoadingCollectionExperiment.Samples"
+      xmlns:local="using:CollectionsExperiment.Samples"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
 
@@ -45,7 +45,7 @@
               CornerRadius="4">
             <ListView x:Name="PeopleListView">
                 <ListView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="local:Person">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
@@ -58,7 +58,7 @@
                             <TextBlock Grid.Column="1"
                                        Margin="12"
                                        VerticalAlignment="Center"
-                                       Text="{Binding Name}" />
+                                       Text="{x:Bind Name}" />
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

This PR fixes #514

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

Bugfix

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->

Switches to `{x:Bind}` instead of `{Binding}` and adds an `x:DataType` to the data template. The bound Name property now shows in this sample with AoT enabled.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->
