### PR TITLE
Update Microsoft.Graphics.Win2D package reference to version 1.3.0

### DIFF
--- a/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
+++ b/components/Behaviors/src/CommunityToolkit.WinUI.Behaviors.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.BehaviorsRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/Collections/src/CommunityToolkit.WinUI.Collections.csproj
+++ b/components/Collections/src/CommunityToolkit.WinUI.Collections.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.CollectionsRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
+++ b/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
@@ -6,6 +6,7 @@
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.ColorPickerRns</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/components/Helpers/src/CommunityToolkit.WinUI.Helpers.csproj
+++ b/components/Helpers/src/CommunityToolkit.WinUI.Helpers.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.HelpersRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/components/ImageCropper/src/Dependencies.props
+++ b/components/ImageCropper/src/Dependencies.props
@@ -21,7 +21,7 @@
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-        <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.30"/>
+        <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.0"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->

--- a/components/Media/src/CommunityToolkit.WinUI.Media.csproj
+++ b/components/Media/src/CommunityToolkit.WinUI.Media.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.MediaRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/Media/src/Dependencies.props
+++ b/components/Media/src/Dependencies.props
@@ -17,6 +17,6 @@
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.0" />
   </ItemGroup>
 </Project>

--- a/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
+++ b/components/Primitives/src/CommunityToolkit.WinUI.Controls.Primitives.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.PrimitivesRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
+++ b/components/RichSuggestBox/src/CommunityToolkit.WinUI.Controls.RichSuggestBox.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.RichSuggestBoxRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
+++ b/components/SettingsControls/src/CommunityToolkit.WinUI.Controls.SettingsControls.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.SettingsControlsRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <!-- Sets this up as a toolkit component's source project -->

--- a/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
+++ b/components/TokenizingTextBox/src/CommunityToolkit.WinUI.Controls.TokenizingTextBox.csproj
@@ -8,6 +8,7 @@
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.TokenizingTextBoxRns</RootNamespace>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates our Win2d dependency to 1.3.0. Notably, this version has a minimum TFM of `net6.0-windows10.0.19041`, wheras the previous 1.1.1 version we were using has a minimum TFM of `net6.0-windows10.0.22621`. 

Since this dependency was the only reason we originally bumped our Windows App SDK TFM to 22621 (see https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/161, https://github.com/microsoft/Win2D/issues/943), we can follow-up with a submodule PR to reduce our TFM back down to 19041. 