### PR TITLE
Update tooling pointer, bump global.json to 8.0.403

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.201",
+    "version": "8.0.403",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 


### PR DESCRIPTION
This PR:
- Updates our tooling pointer to the latest `main` commit.
- Updates `global.json` to use version 8.0.403 instead of 8.0.201. This aligns with the version used by our tooling submodule, and enables implicit properties and project references when building with the Windows App SDK (see https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/221#issuecomment-2438628204)

Changes in tooling include:

[New] 
- Components can now override the TFMs using for a declared MultiTarget. See  https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/218
- Components using the `wasdk` MultiTarget can now set `HasWinUI` to `false` to disable any UI-related dependencies under the TFMs used to target the Windows App SDK, aligning with the current behavior on UWP. See https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/217

[Improvements]
- The default TFM for the `wasdk` MultiTarget is once again using `19041` instead of `22621`.  See 
https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/220