### PR TITLE
SwitchPresenter 2.0 and the new SwitchConverter 🦙❤️

### DIFF
--- a/components/Primitives/samples/Primitives.Samples.csproj
+++ b/components/Primitives/samples/Primitives.Samples.csproj
@@ -63,22 +63,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
-  <ItemGroup>
-    <Compile Update="UniformGridSample.xaml.cs">
-      <DependentUpon>UniformGridSample.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="DockPanelSample.xaml.cs">
-      <DependentUpon>DockPanelSample.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ConstrainedBoxSample.xaml.cs">
-      <DependentUpon>ConstrainedBoxSample.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="StaggeredLayoutSample.xaml.cs">
-      <DependentUpon>StaggeredLayoutSample.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="WrapPanelSample.xaml.cs">
-      <DependentUpon>WrapPanelSample.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
 </Project>

--- a/components/Primitives/samples/SwitchPresenter.md
+++ b/components/Primitives/samples/SwitchPresenter.md
@@ -29,3 +29,9 @@ Or it can simply be used to clearly display different outcomes based on some sta
 `SwitchPresenter` can also be used as a replacement for the deprecated `Loading` control. This provides more fine-grained control over animations and content within each state:
 
 > [!SAMPLE SwitchPresenterLoaderSample]
+
+We can also invert the paradigm a bit with a `SwitchPresenter` to do data transformations within XAML using a `ContentTemplate`. Imagine an alternate view of our first starting example:
+
+> [!SAMPLE SwitchPresenterTemplateSample]
+
+That's right! `SwitchPresenter` can be used not just for displaying different UIElements but in feeding different kinds of data into the `ContentTemplate` as well.

--- a/components/Primitives/samples/SwitchPresenter.md
+++ b/components/Primitives/samples/SwitchPresenter.md
@@ -35,3 +35,9 @@ We can also invert the paradigm a bit with a `SwitchPresenter` to do data transf
 > [!SAMPLE SwitchPresenterTemplateSample]
 
 That's right! `SwitchPresenter` can be used not just for displaying different UIElements but in feeding different kinds of data into the `ContentTemplate` as well.
+
+## SwitchConverter
+
+A new analog to `SwitchPresenter` is the `SwitchConverter` which can be used in bindings to translate values into resources:
+
+> [!SAMPLE SwitchConverterBrushSample]

--- a/components/Primitives/samples/SwitchPresenter/SwitchConverterBrushSample.xaml
+++ b/components/Primitives/samples/SwitchPresenter/SwitchConverterBrushSample.xaml
@@ -20,12 +20,12 @@
         <converters:SwitchConverter x:Key="StatusToColorSwitchConverter"
                                     TargetType="local:CheckStatus">
             <!--  Note: These are reused from the controls namespace from SwitchPresenter  -->
-            <controls:Case Content="{ThemeResource SystemFillColorCriticalBrush}"
-                           Value="Error" />
-            <controls:Case Content="{ThemeResource SystemFillColorCautionBrush}"
-                           Value="Warning" />
             <controls:Case Content="{ThemeResource SystemFillColorSuccessBrush}"
                            Value="Success" />
+            <controls:Case Content="{ThemeResource SystemFillColorCautionBrush}"
+                           Value="Warning" />
+            <controls:Case Content="{ThemeResource SystemFillColorCriticalBrush}"
+                           Value="Error" />
         </converters:SwitchConverter>
     </Page.Resources>
 
@@ -33,9 +33,9 @@
         <ComboBox x:Name="StatusPicker"
                   Header="Pick a status"
                   SelectedIndex="0">
-            <x:String>Error</x:String>
-            <x:String>Warning</x:String>
             <x:String>Success</x:String>
+            <x:String>Warning</x:String>
+            <x:String>Error</x:String>
         </ComboBox>
         <TextBlock Text="This is it, this is the demo:" />
         <TextBlock FontWeight="SemiBold"

--- a/components/Primitives/samples/SwitchPresenter/SwitchConverterBrushSample.xaml
+++ b/components/Primitives/samples/SwitchPresenter/SwitchConverterBrushSample.xaml
@@ -1,0 +1,45 @@
+<Page x:Class="PrimitivesExperiment.Samples.SwitchPresenter.SwitchConverterBrushSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:PrimitivesExperiment.Samples.SwitchPresenter"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:ui="using:CommunityToolkit.WinUI"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <!--
+            If you reference an enum directly in UWP, you need to use it somewhere for the XamlTypeInfo reference to be generated...
+        -->
+        <local:CheckStatus x:Key="MyChecks">Warning</local:CheckStatus>
+
+        <!--  SwitchConverter lets you easily convert general values to resources  -->
+        <!--  Note: This is in the converters namespace  -->
+        <converters:SwitchConverter x:Key="StatusToColorSwitchConverter"
+                                    TargetType="local:CheckStatus">
+            <!--  Note: These are reused from the controls namespace from SwitchPresenter  -->
+            <controls:Case Content="{ThemeResource SystemFillColorCriticalBrush}"
+                           Value="Error" />
+            <controls:Case Content="{ThemeResource SystemFillColorCautionBrush}"
+                           Value="Warning" />
+            <controls:Case Content="{ThemeResource SystemFillColorSuccessBrush}"
+                           Value="Success" />
+        </converters:SwitchConverter>
+    </Page.Resources>
+
+    <StackPanel Spacing="8">
+        <ComboBox x:Name="StatusPicker"
+                  Header="Pick a status"
+                  SelectedIndex="0">
+            <x:String>Error</x:String>
+            <x:String>Warning</x:String>
+            <x:String>Success</x:String>
+        </ComboBox>
+        <TextBlock Text="This is it, this is the demo:" />
+        <TextBlock FontWeight="SemiBold"
+                   Foreground="{x:Bind StatusPicker.SelectedItem, Converter={StaticResource StatusToColorSwitchConverter}, Mode=OneWay}"
+                   Text="{x:Bind StatusPicker.SelectedItem, Mode=OneWay}" />
+    </StackPanel>
+</Page>

--- a/components/Primitives/samples/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
+++ b/components/Primitives/samples/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.WinUI.Converters;
+
+namespace PrimitivesExperiment.Samples.SwitchPresenter;
+
+[ToolkitSample(id: nameof(SwitchConverterBrushSample), "SwitchConverter Brush", description: $"A sample for showing how to use a {nameof(SwitchConverter)} for swapping a brush based on an enum.")]
+public sealed partial class SwitchConverterBrushSample : Page
+{
+    public SwitchConverterBrushSample()
+    {
+        this.InitializeComponent();
+    }
+}
+
+public enum CheckStatus
+{
+    Error,
+    Warning,
+    Success,
+}

--- a/components/Primitives/samples/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
+++ b/components/Primitives/samples/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using PrimitivesExperiment.Samples.ConstrainedBox;
-
 namespace PrimitivesExperiment.Samples.SwitchPresenter;
 
 [ToolkitSample(id: nameof(SwitchPresenterLayoutSample), "SwitchPresenter Layout", description: $"A sample for showing how to use a {nameof(SwitchPresenter)} for complex layouts.")]

--- a/components/Primitives/samples/SwitchPresenter/SwitchPresenterTemplateSample.xaml
+++ b/components/Primitives/samples/SwitchPresenter/SwitchPresenterTemplateSample.xaml
@@ -1,0 +1,54 @@
+<Page x:Class="PrimitivesExperiment.Samples.SwitchPresenter.SwitchPresenterTemplateSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:PrimitivesExperiment.Samples.SwitchPresenter"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:ui="using:CommunityToolkit.WinUI"
+      mc:Ignorable="d">
+
+    <StackPanel>
+        <ComboBox x:Name="Lookup"
+                  Margin="0,0,0,8"
+                  Header="Look up reservation"
+                  SelectedIndex="0">
+            <x:String>Confirmation Code</x:String>
+            <x:String>E-ticket number</x:String>
+            <x:String>Mileage Plan number</x:String>
+        </ComboBox>
+        <!--  SwitchPresenter binds to a value  -->
+        <controls:SwitchPresenter Value="{x:Bind Lookup.SelectedItem, Mode=OneWay}">
+            <!--  We define a common UI template for the data we want to display  -->
+            <controls:SwitchPresenter.ContentTemplate>
+                <DataTemplate x:DataType="local:TemplateInformation">
+                    <StackPanel>
+                        <TextBox Name="CodeValidator"
+                                 ui:TextBoxExtensions.Regex="{x:Bind Regex, Mode=OneWay}"
+                                 Header="{x:Bind Header, Mode=OneWay}"
+                                 PlaceholderText="{x:Bind PlaceholderText, Mode=OneWay}" />
+                        <TextBlock Text="Thanks for entering a valid code!"
+                                   Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=CodeValidator}" />
+                    </StackPanel>
+                </DataTemplate>
+            </controls:SwitchPresenter.ContentTemplate>
+            <!--  And use the value to transform our data into an object we'll use as the context for our UI  -->
+            <controls:Case IsDefault="True"
+                           Value="Confirmation Code">
+                <local:TemplateInformation Header="Confirmation code"
+                                           PlaceholderText="6 letters"
+                                           Regex="^[a-zA-Z]{6}$" />
+            </controls:Case>
+            <controls:Case Value="E-ticket number">
+                <local:TemplateInformation Header="E-ticket number"
+                                           PlaceholderText="10 or 13 numbers"
+                                           Regex="(^\d{10}$)|(^\d{13}$)" />
+            </controls:Case>
+            <controls:Case Value="Mileage Plan number">
+                <local:TemplateInformation Header="Mileage Plan #"
+                                           PlaceholderText="Mileage Plan (12 digits)"
+                                           Regex="(^\d{12}$)" />
+            </controls:Case>
+        </controls:SwitchPresenter>
+    </StackPanel>
+</Page>

--- a/components/Primitives/samples/SwitchPresenter/SwitchPresenterTemplateSample.xaml.cs
+++ b/components/Primitives/samples/SwitchPresenter/SwitchPresenterTemplateSample.xaml.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PrimitivesExperiment.Samples.SwitchPresenter;
+
+[ToolkitSample(id: nameof(SwitchPresenterTemplateSample), "SwitchPresenter Template", description: $"A sample for showing how to use a {nameof(SwitchPresenter)} with a Content Template.")]
+public sealed partial class SwitchPresenterTemplateSample : Page
+{
+    public SwitchPresenterTemplateSample()
+    {
+        this.InitializeComponent();
+    }
+}
+
+public partial class TemplateInformation
+{
+    public string? Header { get; set; }
+
+    public string? Regex { get; set; }
+
+    public string? PlaceholderText { get; set; } 
+}
+

--- a/components/Primitives/samples/SwitchPresenter/SwitchPresenterValueSample.xaml
+++ b/components/Primitives/samples/SwitchPresenter/SwitchPresenterValueSample.xaml
@@ -23,6 +23,10 @@
         <controls:SwitchPresenter Padding="16"
                                   TargetType="local:Animal"
                                   Value="{Binding SelectedItem, ElementName=AnimalPicker}">
+            <controls:Case Value="Bunny">
+                <TextBlock FontSize="32"
+                           Text="🐇" />
+            </controls:Case>
             <controls:Case Value="Cat">
                 <TextBlock FontSize="32"
                            Text="🐈" />
@@ -31,13 +35,21 @@
                 <TextBlock FontSize="32"
                            Text="🐕" />
             </controls:Case>
-            <controls:Case Value="Bunny">
+            <controls:Case Value="Giraffe">
                 <TextBlock FontSize="32"
-                           Text="🐇" />
+                           Text="🦒" />
             </controls:Case>
             <controls:Case Value="Llama">
                 <TextBlock FontSize="32"
                            Text="🦙" />
+            </controls:Case>
+            <controls:Case Value="Otter">
+                <TextBlock FontSize="32"
+                           Text="🦦" />
+            </controls:Case>
+            <controls:Case Value="Owl">
+                <TextBlock FontSize="32"
+                           Text="🦉" />
             </controls:Case>
             <controls:Case Value="Parrot">
                 <TextBlock FontSize="32"

--- a/components/Primitives/samples/SwitchPresenter/SwitchPresenterValueSample.xaml
+++ b/components/Primitives/samples/SwitchPresenter/SwitchPresenterValueSample.xaml
@@ -22,7 +22,7 @@
                   SelectedIndex="0" />
         <controls:SwitchPresenter Padding="16"
                                   TargetType="local:Animal"
-                                  Value="{Binding SelectedItem, ElementName=AnimalPicker}">
+                                  Value="{x:Bind AnimalPicker.SelectedItem, Mode=OneWay}">
             <controls:Case Value="Bunny">
                 <TextBlock FontSize="32"
                            Text="🐇" />

--- a/components/Primitives/samples/SwitchPresenter/SwitchPresenterValueSample.xaml.cs
+++ b/components/Primitives/samples/SwitchPresenter/SwitchPresenterValueSample.xaml.cs
@@ -15,10 +15,13 @@ public sealed partial class SwitchPresenterValueSample : Page
 
 public enum Animal
 {
+    Bunny,
     Cat,
     Dog,
-    Bunny,
+    Giraffe,
     Llama,
+    Otter,
+    Owl,
     Parrot,
     Squirrel
 }

--- a/components/Primitives/src/SwitchPresenter/Case.cs
+++ b/components/Primitives/src/SwitchPresenter/Case.cs
@@ -13,9 +13,9 @@ public partial class Case : DependencyObject
     /// <summary>
     /// Gets or sets the Content to display when this case is active.
     /// </summary>
-    public UIElement Content
+    public object Content
     {
-        get { return (UIElement)GetValue(ContentProperty); }
+        get { return (object)GetValue(ContentProperty); }
         set { SetValue(ContentProperty, value); }
     }
 
@@ -23,7 +23,7 @@ public partial class Case : DependencyObject
     /// Identifies the <see cref="Content"/> property.
     /// </summary>
     public static readonly DependencyProperty ContentProperty =
-        DependencyProperty.Register(nameof(Content), typeof(UIElement), typeof(Case), new PropertyMetadata(null));
+        DependencyProperty.Register(nameof(Content), typeof(object), typeof(Case), new PropertyMetadata(null));
 
     /// <summary>
     /// Gets or sets a value indicating whether this is the default case to display when no values match the specified value in the <see cref="SwitchPresenter"/>. There should only be a single default case provided. Do not set the <see cref="Value"/> property when setting <see cref="IsDefault"/> to <c>true</c>. Default is <c>false</c>.

--- a/components/Primitives/src/SwitchPresenter/SwitchConverter.cs
+++ b/components/Primitives/src/SwitchPresenter/SwitchConverter.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.WinUI.Controls;
+
+namespace CommunityToolkit.WinUI.Converters;
+
+/// <summary>
+/// A helper <see cref="IValueConverter"/> which can automatically translate incoming data to a set of resulting values defined in XAML.
+/// </summary>
+/// <example>
+/// &lt;converters:SwitchConverter x:Key=&quot;StatusToColorSwitchConverter&quot;
+///                                TargetType=&quot;models:CheckStatus&quot;&gt;
+///     &lt;controls:Case Value=&quot;Error&quot; Content=&quot;{ThemeResource SystemFillColorCriticalBrush}&quot;/&gt;
+///     &lt;controls:Case Value=&quot;Warning&quot; Content=&quot;{ThemeResource SystemFillColorCautionBrush}&quot;/&gt;
+///     &lt;controls:Case Value=&quot;Success&quot; Content=&quot;{ThemeResource SystemFillColorSuccessBrush}&quot;/&gt;
+/// &lt;/converters:SwitchConverter&gt;
+/// ...
+/// &lt;TextBlock
+///     FontWeight=&quot;SemiBold&quot;
+///     Foreground=&quot;{x:Bind Status, Converter={StaticResource StatusToColorSwitchConverter}}&quot;
+///     Text = &quot;{x:Bind Status}&quot; /&gt;
+/// </example>
+[ContentProperty(Name = nameof(SwitchCases))]
+public sealed partial class SwitchConverter : DependencyObject, IValueConverter
+{
+    /// <summary>
+    /// Gets or sets a value representing the collection of cases to evaluate.
+    /// </summary>
+    public CaseCollection SwitchCases
+    {
+        get { return (CaseCollection)GetValue(SwitchCasesProperty); }
+        set { SetValue(SwitchCasesProperty, value); }
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="SwitchCases"/> property.
+    /// </summary>
+    public static readonly DependencyProperty SwitchCasesProperty =
+        DependencyProperty.Register(nameof(SwitchCases), typeof(CaseCollection), typeof(SwitchConverter), new PropertyMetadata(null));
+
+    /// <summary>
+    /// Gets or sets a value indicating which type to first cast and compare provided values against.
+    /// </summary>
+    public Type TargetType
+    {
+        get { return (Type)GetValue(TargetTypeProperty); }
+        set { SetValue(TargetTypeProperty, value); }
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="TargetType"/> property.
+    /// </summary>
+    public static readonly DependencyProperty TargetTypeProperty =
+        DependencyProperty.Register(nameof(TargetType), typeof(Type), typeof(SwitchConverter), new PropertyMetadata(null));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwitchPresenter"/> class.
+    /// </summary>
+    public SwitchConverter()
+    {
+        // Note: we need to initialize this here so that XAML can automatically add cases without needing this defined around it as the content.
+        // We don't do this in the PropertyMetadata as then we create a static shared collection for all converters, which we don't want. We want it per instance.
+        // See https://learn.microsoft.com/windows/uwp/xaml-platform/custom-dependency-properties#initializing-the-collection
+        SwitchCases = new CaseCollection();
+    }
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var result = SwitchCases.EvaluateCases(value, TargetType ?? targetType);
+
+        return result?.Content!;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/components/Primitives/src/SwitchPresenter/SwitchHelpers.cs
+++ b/components/Primitives/src/SwitchPresenter/SwitchHelpers.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.WinUI.Converters;
+
+namespace CommunityToolkit.WinUI.Controls;
+
+/// <summary>
+/// Internal helpers for use between <see cref="SwitchPresenter"/> and <see cref="SwitchConverter"/>.
+/// The logic here is the main code which looks across a <see cref="CaseCollection"/>  to match a specific <see cref="Case"/> with a given value while converting types based on the <see cref="SwitchPresenter.TargetType"/> property. This will handle <see cref="Enum"/> values as well as values compatible with the <see cref="XamlBindingHelper.ConvertValue(Type, object)"/> method.
+/// </summary>
+internal static partial class SwitchHelpers
+{
+    /// <summary>
+    /// Extension method for a set of cases to find the matching case given its value and type.
+    /// </summary>
+    /// <param name="switchCases">The collection of <see cref="Case"/>s in a <see cref="CaseCollection"/></param>
+    /// <param name="value">The value of the <see cref="Case"/> to find</param>
+    /// <param name="targetType">The desired type of the result for automatic conversion</param>
+    /// <returns>The discovered value, the default value, or <c>null</c></returns>
+    internal static Case? EvaluateCases(this CaseCollection switchCases, object value, Type targetType)
+    {
+        if (switchCases == null ||
+            switchCases.Count == 0)
+        {
+            // If we have no cases, then we can't match anything.
+            return null;
+        }
+
+        Case? xdefault = null;
+        Case? newcase = null;
+
+        foreach (Case xcase in switchCases)
+        {
+            if (xcase.IsDefault)
+            {
+                // If there are multiple default cases provided, this will override and just grab the last one, the developer will have to fix this in their XAML. We call this out in the case comments.
+                xdefault = xcase;
+                continue;
+            }
+
+            if (CompareValues(value, xcase.Value, targetType))
+            {
+                newcase = xcase;
+                break;
+            }
+        }
+
+        if (newcase == null && xdefault != null)
+        {
+            // Inject default if we found one without matching anything
+            newcase = xdefault;
+        }
+
+        return newcase;
+    }
+
+    /// <summary>
+    /// Compares two values using the TargetType.
+    /// </summary>
+    /// <param name="compare">Our main value in our SwitchPresenter.</param>
+    /// <param name="value">The value from the case to compare to.</param>
+    /// <returns>true if the two values are equal</returns>
+    internal static bool CompareValues(object compare, object value, Type targetType)
+    {
+        if (compare == null || value == null)
+        {
+            return compare == value;
+        }
+
+        if (targetType == null ||
+            (targetType == compare.GetType() &&
+             targetType == value.GetType()))
+        {
+            // Default direct object comparison or we're all the proper type
+            return compare.Equals(value);
+        }
+        else if (compare.GetType() == targetType)
+        {
+            // If we have a TargetType and the first value is the right type
+            // Then our 2nd value isn't, so convert to string and coerce.
+            var valueBase2 = ConvertValue(targetType, value);
+
+            return compare.Equals(valueBase2);
+        }
+
+        // Neither of our two values matches the type so
+        // we'll convert both to a String and try and coerce it to the proper type.
+        var compareBase = ConvertValue(targetType, compare);
+
+        var valueBase = ConvertValue(targetType, value);
+
+        return compareBase.Equals(valueBase);
+    }
+
+    /// <summary>
+    /// Helper method to convert a value from a source type to a target type.
+    /// </summary>
+    /// <param name="targetType">The target type</param>
+    /// <param name="value">The value to convert</param>
+    /// <returns>The converted value</returns>
+    internal static object ConvertValue(Type targetType, object value)
+    {
+        if (targetType.IsInstanceOfType(value))
+        {
+            return value;
+        }
+        else if (targetType.IsEnum && value is string str)
+        {
+#if HAS_UNO
+            if (Enum.IsDefined(targetType, str))
+            {
+                return Enum.Parse(targetType, str);
+            }
+#else
+            if (Enum.TryParse(targetType, str, out object? result))
+            {
+                return result!;
+            }
+#endif
+
+            static object ThrowExceptionForKeyNotFound()
+            {
+                throw new InvalidOperationException("The requested enum value was not present in the provided type.");
+            }
+
+            return ThrowExceptionForKeyNotFound();
+        }
+        else
+        {
+            return XamlBindingHelper.ConvertValue(targetType, value);
+        }
+    }
+}

--- a/components/Primitives/src/SwitchPresenter/SwitchPresenter.cs
+++ b/components/Primitives/src/SwitchPresenter/SwitchPresenter.cs
@@ -115,20 +115,7 @@ public sealed partial class SwitchPresenter : ContentPresenter
 
     private void EvaluateCases()
     {
-        if (SwitchCases == null ||
-            SwitchCases.Count == 0)
-        {
-            // If we have no cases, then we can't match anything.
-            if (CurrentCase != null)
-            {
-                // Only bother clearing our actual content if we had something before.
-                Content = null;
-                CurrentCase = null;
-            }
-
-            return;
-        }
-        else if (CurrentCase?.Value != null &&
+        if (CurrentCase?.Value != null &&
             CurrentCase.Value.Equals(Value))
         {
             // If the current case we're on already matches our current value,
@@ -136,114 +123,14 @@ public sealed partial class SwitchPresenter : ContentPresenter
             return;
         }
 
-        Case? xdefault = null;
-        Case? newcase = null;
+        var result = SwitchCases.EvaluateCases(Value, TargetType);
 
-        foreach (Case xcase in SwitchCases)
-        {
-            if (xcase.IsDefault)
-            {
-                // If there are multiple default cases provided, this will override and just grab the last one, the developer will have to fix this in their XAML. We call this out in the case comments.
-                xdefault = xcase;
-                continue;
-            }
-
-            if (CompareValues(Value, xcase.Value))
-            {
-                newcase = xcase;
-                break;
-            }
-        }
-
-        if (newcase == null && xdefault != null)
-        {
-            // Inject default if we found one without matching anything
-            newcase = xdefault;
-        }
-
-        // Only bother changing things around if we actually have a new case.
-        if (newcase != CurrentCase)
+        // Only bother changing things around if we actually have a new case. (this should handle prior null case as well)
+        if (result != CurrentCase)
         {
             // If we don't have any cases or default, setting these to null is what we want to be blank again.
-            Content = newcase?.Content;
-            CurrentCase = newcase;
-        }
-    }
-
-    /// <summary>
-    /// Compares two values using the TargetType.
-    /// </summary>
-    /// <param name="compare">Our main value in our SwitchPresenter.</param>
-    /// <param name="value">The value from the case to compare to.</param>
-    /// <returns>true if the two values are equal</returns>
-    private bool CompareValues(object compare, object value)
-    {
-        if (compare == null || value == null)
-        {
-            return compare == value;
-        }
-
-        if (TargetType == null ||
-            (TargetType == compare.GetType() &&
-             TargetType == value.GetType()))
-        {
-            // Default direct object comparison or we're all the proper type
-            return compare.Equals(value);
-        }
-        else if (compare.GetType() == TargetType)
-        {
-            // If we have a TargetType and the first value is the right type
-            // Then our 2nd value isn't, so convert to string and coerce.
-            var valueBase2 = ConvertValue(TargetType, value);
-
-            return compare.Equals(valueBase2);
-        }
-
-        // Neither of our two values matches the type so
-        // we'll convert both to a String and try and coerce it to the proper type.
-        var compareBase = ConvertValue(TargetType, compare);
-
-        var valueBase = ConvertValue(TargetType, value);
-
-        return compareBase.Equals(valueBase);
-    }
-
-    /// <summary>
-    /// Helper method to convert a value from a source type to a target type.
-    /// </summary>
-    /// <param name="targetType">The target type</param>
-    /// <param name="value">The value to convert</param>
-    /// <returns>The converted value</returns>
-    internal static object ConvertValue(Type targetType, object value)
-    {
-        if (targetType.IsInstanceOfType(value))
-        {
-            return value;
-        }
-        else if (targetType.IsEnum && value is string str)
-        {
-#if HAS_UNO
-            if (Enum.IsDefined(targetType, str))
-            {
-                return Enum.Parse(targetType, str);
-            }
-#else
-            if (Enum.TryParse(targetType, str, out object? result))
-            {
-                return result!;
-            }
-#endif
-
-            static object ThrowExceptionForKeyNotFound()
-            {
-                throw new InvalidOperationException("The requested enum value was not present in the provided type.");
-            }
-
-            return ThrowExceptionForKeyNotFound();
-        }
-        else
-        {
-            return XamlBindingHelper.ConvertValue(targetType, value);
+            Content = result?.Content;
+            CurrentCase = result;
         }
     }
 }

--- a/components/Primitives/tests/Primitives.Tests.projitems
+++ b/components/Primitives/tests/Primitives.Tests.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>PrimitivesExperiment.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchConverterBrushSample.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchPresenterLayoutSample.xaml.cs">
       <DependentUpon>%(Filename)</DependentUpon>
     </Compile>
@@ -38,6 +41,10 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchConverterBrushSample.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchPresenterLayoutSample.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/components/Primitives/tests/Primitives.Tests.projitems
+++ b/components/Primitives/tests/Primitives.Tests.projitems
@@ -9,6 +9,10 @@
     <Import_RootNamespace>PrimitivesExperiment.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchPresenterLayoutSample.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchPresenterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Test_ConstrainedBox.Alignment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Test_ConstrainedBox.AspectRatio.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Test_ConstrainedBox.Coerce.cs" />
@@ -29,6 +33,12 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)UniformGrid\AutoLayoutFixedElementZeroZeroSpecialPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchPresenterLayoutSample.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml
+++ b/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml
@@ -1,0 +1,53 @@
+<Page x:Class="PrimitivesExperiment.Tests.SwitchConverterBrushSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:PrimitivesExperiment.Tests"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:ui="using:CommunityToolkit.WinUI"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <!--
+            If you reference an enum directly in UWP, you need to use it somewhere for the XamlTypeInfo reference to be generated...
+        -->
+        <local:CheckStatus x:Key="MyChecks">Warning</local:CheckStatus>
+
+        <!--  Make it easier for us to retrieve these to compare from test  -->
+        <StaticResource x:Key="SystemFillColorSuccessBrush"
+                        ResourceKey="SystemFillColorSuccessBrush" />
+        <StaticResource x:Key="SystemFillColorCautionBrush"
+                        ResourceKey="SystemFillColorCautionBrush" />
+        <StaticResource x:Key="SystemFillColorCriticalBrush"
+                        ResourceKey="SystemFillColorCriticalBrush" />
+
+        <!--  SwitchConverter lets you easily convert general values to resources  -->
+        <!--  Note: This is in the converters namespace  -->
+        <converters:SwitchConverter x:Key="StatusToColorSwitchConverter"
+                                    TargetType="local:CheckStatus">
+            <!--  Note: These are reused from the controls namespace from SwitchPresenter  -->
+            <controls:Case Content="{ThemeResource SystemFillColorSuccessBrush}"
+                           Value="Success" />
+            <controls:Case Content="{ThemeResource SystemFillColorCautionBrush}"
+                           Value="Warning" />
+            <controls:Case Content="{ThemeResource SystemFillColorCriticalBrush}"
+                           Value="Error" />
+        </converters:SwitchConverter>
+    </Page.Resources>
+
+    <StackPanel Spacing="8">
+        <ComboBox x:Name="StatusPicker"
+                  Header="Pick a status"
+                  SelectedIndex="0">
+            <x:String>Success</x:String>
+            <x:String>Warning</x:String>
+            <x:String>Error</x:String>
+        </ComboBox>
+        <TextBlock x:Name="ResultBlock"
+                   FontWeight="SemiBold"
+                   Foreground="{x:Bind StatusPicker.SelectedItem, Converter={StaticResource StatusToColorSwitchConverter}, Mode=OneWay}"
+                   Text="{x:Bind StatusPicker.SelectedItem, Mode=OneWay}" />
+    </StackPanel>
+</Page>

--- a/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PrimitivesExperiment.Tests;
+
+public sealed partial class SwitchConverterBrushSample : Page
+{
+    public SwitchConverterBrushSample()
+    {
+        this.InitializeComponent();
+    }
+}
+
+public enum CheckStatus
+{
+    Error,
+    Warning,
+    Success,
+}

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml
@@ -1,0 +1,54 @@
+<Page x:Class="PrimitivesExperiment.Tests.SwitchPresenterLayoutSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:ui="using:CommunityToolkit.WinUI"
+      mc:Ignorable="d">
+
+    <StackPanel>
+        <ComboBox x:Name="Lookup"
+                  Margin="0,0,0,8"
+                  Header="Look up reservation"
+                  SelectedIndex="0">
+            <x:String>Select an option</x:String>
+            <x:String>Confirmation Code</x:String>
+            <x:String>E-ticket number</x:String>
+            <x:String>Mileage Plan number</x:String>
+        </ComboBox>
+        <!--  SwitchPresenter binds to a value  -->
+        <controls:SwitchPresenter Value="{Binding SelectedItem, ElementName=Lookup}">
+            <!--  And then only dynamically displays the Case with the matching Value  -->
+            <controls:Case Value="Confirmation Code">
+                <StackPanel>
+                    <TextBox Name="ConfirmationCodeValidator"
+                             ui:TextBoxExtensions.Regex="^[a-zA-Z]{6}$"
+                             Header="Confirmation code"
+                             PlaceholderText="6 letters" />
+                    <TextBlock Text="Thanks for entering a valid code!"
+                               Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=ConfirmationCodeValidator}" />
+                </StackPanel>
+            </controls:Case>
+            <controls:Case Value="E-ticket number">
+                <StackPanel>
+                    <TextBox Name="TicketValidator"
+                             ui:TextBoxExtensions.Regex="(^\d{10}$)|(^\d{13}$)"
+                             Header="E-ticket number"
+                             PlaceholderText="10 or 13 numbers" />
+                    <TextBlock Text="Thanks for entering a valid code!"
+                               Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=TicketValidator}" />
+                </StackPanel>
+            </controls:Case>
+            <controls:Case Value="Mileage Plan number">
+                <TextBox Name="PlanValidator"
+                         Header="Mileage Plan #"
+                         PlaceholderText="Mileage Plan #" />
+            </controls:Case>
+            <!--  You can also provide a default case if no match is found  -->
+            <controls:Case IsDefault="True">
+                <TextBlock Text="Please select a way to lookup your reservation above..." />
+            </controls:Case>
+        </controls:SwitchPresenter>
+    </StackPanel>
+</Page>

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PrimitivesExperiment.Tests;
+
+public sealed partial class SwitchPresenterLayoutSample : Page
+{
+    public SwitchPresenterLayoutSample()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
@@ -1,0 +1,51 @@
+using CommunityToolkit.Tests;
+using CommunityToolkit.Tooling.TestGen;
+using CommunityToolkit.WinUI.Controls;
+
+namespace PrimitivesExperiment.Tests;
+
+[TestClass]
+public partial class SwitchPresenterTests : VisualUITestBase
+{
+    [UIThreadTestMethod]
+    public async Task SwitchPresenterLayoutTest(SwitchPresenterLayoutSample page)
+    {
+        var spresenter = page.FindDescendant<SwitchPresenter>();
+        var combobox = page.FindDescendant<ComboBox>();
+
+        Assert.IsNotNull(spresenter, "Couldn't find SwitchPresenter");
+        Assert.IsNotNull(combobox, "Couldn't find ComboBox");
+
+        var dcase = spresenter.SwitchCases.OfType<Case>().FirstOrDefault(@case => @case.IsDefault);
+
+        Assert.IsNotNull(dcase, "Couldn't find default case");
+
+        // Are we in our initial case?
+        Assert.AreEqual("Select an option", spresenter.Value, "SwitchPresenter not expected starting value");
+        Assert.AreEqual(dcase, spresenter.CurrentCase, "SwitchPresenter not at current default case");
+
+        // Can we find our matching textbox?
+        var tbox = spresenter.FindDescendant<TextBlock>();
+        Assert.IsNotNull(tbox, "Couldn't find inner textbox");
+        Assert.AreEqual("Please select a way to lookup your reservation above...", tbox.Text, "Unexpected content for SwitchPresenter default case");
+
+        // Update combobox
+        combobox.SelectedIndex = 1;
+
+        // Wait for update
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        // Are we in the new case?
+        Assert.AreEqual("Confirmation Code", spresenter.Value);
+
+        var ccase = spresenter.SwitchCases.OfType<Case>().FirstOrDefault(@case => @case.Value?.ToString() == "Confirmation Code");
+
+        Assert.IsNotNull(ccase, "Couldn't find expected case");
+
+        Assert.AreEqual(ccase, spresenter.CurrentCase, "SwitchPresenter didn't change cases");
+
+        var txtbox = spresenter.FindDescendant<TextBox>();
+        Assert.IsNotNull(txtbox, "Couldn't find new textbox");
+        Assert.AreEqual("Confirmation code", txtbox.Header, "Textbox header not expected value");
+    }
+}

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
@@ -1,6 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Controls;
+using CommunityToolkit.WinUI.Converters;
 
 namespace PrimitivesExperiment.Tests;
 
@@ -47,5 +52,91 @@ public partial class SwitchPresenterTests : VisualUITestBase
         var txtbox = spresenter.FindDescendant<TextBox>();
         Assert.IsNotNull(txtbox, "Couldn't find new textbox");
         Assert.AreEqual("Confirmation code", txtbox.Header, "Textbox header not expected value");
+    }
+
+    [UIThreadTestMethod]
+    public async Task SwitchConverterBrushTest(SwitchConverterBrushSample page)
+    {
+        var combobox = page.FindDescendant<ComboBox>();
+        var textblock = page.FindDescendant("ResultBlock") as TextBlock;
+
+        Assert.IsNotNull(combobox, "Couldn't find ComboBox");
+        Assert.IsNotNull(textblock, "Couldn't find SwitchPresenter");
+
+        // Are we in our initial case?
+        Assert.AreEqual(0, combobox.SelectedIndex, "ComboBox not initialized");
+        Assert.AreEqual("Success", combobox.SelectedItem, "Not expected starting value in ComboBox");
+
+        // Check the TextBlock's brush
+        Assert.AreEqual(((SolidColorBrush)page.Resources["SystemFillColorSuccessBrush"]).Color, ((SolidColorBrush)textblock.Foreground).Color, "TextBlock not in initial success state");
+
+        // Update combobox
+        combobox.SelectedIndex = 1;
+
+        // Wait for update
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        // Are we in the new case?
+        Assert.AreEqual("Warning", combobox.SelectedItem, "ComboBox didn't change");
+
+        // Check the TextBlock's brush
+        Assert.AreEqual(((SolidColorBrush)page.Resources["SystemFillColorCautionBrush"]).Color, ((SolidColorBrush)textblock.Foreground).Color, "TextBlock not in new state");
+
+        // Update combobox
+        combobox.SelectedIndex = 2;
+
+        // Wait for update
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        // Are we in the new case?
+        Assert.AreEqual("Error", combobox.SelectedItem, "ComboBox didn't change 2");
+
+        // Check the TextBlock's brush
+        Assert.AreEqual(((SolidColorBrush)page.Resources["SystemFillColorCriticalBrush"]).Color, ((SolidColorBrush)textblock.Foreground).Color, "TextBlock not in final state");
+    }
+
+    [UIThreadTestMethod]
+    public void SwitchConverterDirectTest()
+    {
+        // Multiply by 10
+        SwitchConverter sconverter = new()
+        {
+            SwitchCases = new CaseCollection {
+                new Case()
+                {
+                    Content = 10,
+                    Value = 1,
+                },
+                new Case()
+                {
+                    Content = 50,
+                    Value = 5,
+                    IsDefault = true
+                },
+                new Case()
+                {
+                    Content = 30,
+                    Value = 3,
+                },
+                new Case()
+                {
+                    Content = 20,
+                    Value = 2,
+                },
+            },
+            TargetType = typeof(int)
+        };
+
+        Assert.IsNotNull(sconverter);
+        Assert.AreEqual(4, sconverter.SwitchCases.Count, "Not 4 cases");
+
+        var @default = sconverter.Convert(100, typeof(int), string.Empty, string.Empty);
+
+        Assert.AreEqual(50, @default, "Unexpected default return");
+
+        Assert.AreEqual(10, sconverter.Convert(1, typeof(int), string.Empty, string.Empty), "Unexpected result with 1");
+        Assert.AreEqual(20, sconverter.Convert(2, typeof(int), string.Empty, string.Empty), "Unexpected result with 2");
+        Assert.AreEqual(30, sconverter.Convert(3, typeof(int), string.Empty, string.Empty), "Unexpected result with 3");
+        Assert.AreEqual(50, sconverter.Convert(5, typeof(int), string.Empty, string.Empty), "Unexpected result with 5");
     }
 }


### PR DESCRIPTION
## Fixes

Note this _does not_ make an attempt at #516 for WinUI 3, that issue still needs resolution orthogonal to these changes. The specific new functionality works fine and has been tested on UWP, WinUI 3, and Uno Platform WASM.

## PR Type

What kind of change does this PR introduce?

- New Feature

## What is the current behavior?

`ContentPresenter.Content` is an `object` and can take general values/objects beyond just UIElements as it can use a `ContentTemplate` to transform that into UIElements.

This ability has been missing in `SwitchPresenter` as `Case.Content` was restricted to `UIElement` only.

We also have been able to use the same switch like power for transforming values within bindings/expressions.

## What is the new behavior?

- `Case.Content` is now an `object`
  - This allows us to use `SwitchPresenter.ContentTemplate` and transform data in new ways within the confines of XAML
  - You can now use a SwitchPresenter to look at a value and return some new state/configuration/object instead which then seeds your UI `DataTemplate`, see new sample.
  - There's probably more ways this can be leveraged, yet to be discovered
- The core logic of SwitchPresenter has been abstracted to `SwitchHelpers` internal static class and generalized
  - This was done for code-reuse and simplification/separation of logic for the new `SwitchConverter`
  - The EvaluateCases extension is simpler and looks at the general cases to return the behavior vs. thinking about the end result
    - That is now handled by the parent
- Introducing `SwitchConverter`! This infuses the power of `SwitchPresenter` into a `IValueConverter` and allows you to easily transform possible values into resources, like brushes.
  - The new sample shows this where you can take an enum status value and get the corresponding brush easily from within XAML, before this would have had to be a custom converter with custom properties, now it can all be cleanly defined in XAML

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [x] New component
  - [x] Documentation has been added
  - [x] Sample in sample app has been added
  - [x] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [x] Header has been added to all new source files
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

Note: This couldn't have been done from Labs as `SwitchConverter` requires the change in the base `Case.Content` to `object` as well to function, so everything would have to be duplicated. Enabling new scenarios for `SwitchPresenter` and sharing the code makes the most sense here.
