### PR TITLE
Update uno-check version to 1.27.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "uno.check": {
-      "version": "1.20.2",
+      "version": "1.27.1",
       "commands": [
         "uno-check"
       ]


### PR DESCRIPTION
We're seeing widespread [CI failure](https://github.com/CommunityToolkit/Windows/actions/runs/11849075557) in the uno-check step. 
```
==workloadRollbackDefinitionJsonOutputEnd==
  × android (Microsoft.NET.Sdk.Android.Manifest-8.0.100 : 34.0.79/8.0.100) not 
installed.
  × ios (Microsoft.NET.Sdk.iOS.Manifest-8.0.100 : 17.2.8022/8.0.100) not 
installed.
  × maccatalyst (Microsoft.NET.Sdk.MacCatalyst.Manifest-8.0.100 : 
17.2.8022/8.0.100) not installed.
  × macos (Microsoft.NET.Sdk.macOS.Manifest-8.0.100 : 14.2.8022/8.0.100) not 
installed.
  × maui (Microsoft.NET.Sdk.Maui.Manifest-8.0.100 : 8.0.6/8.0.100) not 
installed.
```

This PR attempts to remedy the issue by updating uno-check to the latest version. 

Prerequisite PR: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/229