### PR TITLE
Upgrade to .NET 9.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/devcontainers/images/tree/main/src/dotnet for image choices
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:8.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:9.0
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		"args": {
 			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
 			// Append -bullseye or -focal to pin to an OS version.
-			"VARIANT": "8.0",
+			"VARIANT": "9.0",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
   merge_group:
 
 env:
-  DOTNET_VERSION: ${{ '8.0.201' }}
+  DOTNET_VERSION: ${{ '9.0.100' }}
   ENABLE_DIAGNOSTICS: true
   MSBUILD_VERBOSITY: normal
   #COREHOST_TRACE: 1

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.7.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.12.1" PrivateAssets="all" Pack="false" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -16,7 +16,7 @@
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.1-uno.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.4.2" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
@@ -26,6 +26,6 @@
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.3.1-uno.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.4.2" />
   </ItemGroup>
 </Project>

--- a/components/Converters/src/ResourceNameToResourceStringConverter.cs
+++ b/components/Converters/src/ResourceNameToResourceStringConverter.cs
@@ -34,15 +34,16 @@ public sealed partial class ResourceNameToResourceStringConverter : IValueConver
     /// <returns>The string corresponding to the resource name.</returns>
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        if (value == null)
+        var stringValue = value?.ToString();
+        if (stringValue is null)
         {
             return string.Empty;
         }
 
 #if WINAPPSDK && !HAS_UNO
-        return _resourceManager.MainResourceMap.TryGetValue(value.ToString()).ValueAsString;
+        return _resourceManager.MainResourceMap.TryGetValue(stringValue).ValueAsString;
 #else
-        return _resourceLoader.GetString(value.ToString());
+        return _resourceLoader.GetString(stringValue) ?? string.Empty;
 #endif
     }
 

--- a/components/Extensions/src/Text/StringExtensions.Localization.cs
+++ b/components/Extensions/src/Text/StringExtensions.Localization.cs
@@ -54,11 +54,11 @@ public static partial class StringExtensions
         if (uiContext != null)
         {
             var resourceLoader = ResourceLoader.GetForUIContext(uiContext);
-            return resourceLoader.GetString(resourceKey);
+            return resourceLoader?.GetString(resourceKey) ?? string.Empty;
         }
         else
         {
-            return ResourceLoader.GetForCurrentView().GetString(resourceKey);
+            return ResourceLoader.GetForCurrentView().GetString(resourceKey) ?? string.Empty;
         }
     }
 #endif

--- a/components/Media/src/Dependencies.props
+++ b/components/Media/src/Dependencies.props
@@ -12,7 +12,7 @@
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
     <PackageReference Include="Win2D.uwp" Version="1.28.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.403",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 


### PR DESCRIPTION
This PR updates our tooling to .NET 9.0.100, including updates to:
- TargetFrameworks
  - Added alongside existing TFMs for Uno and Wasdk
  - Update tooling to handle multi-tfm value for Uno
- Dockerfile and devcontainer (used by VS Code, locally & Codespaces)
- GitHub Actions CI (build.yml)
- global.json (selects dotnet version used by runtime)
- Dependent packages (Uno Platform)
- Misc error fixes in components for net9.0.

Prerequisite PR:
https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/230