### PR TITLE
Specify directory for dotnet to install to and execute from.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ on:
 
 env:
   DOTNET_VERSION: ${{ '8.0.201' }}
+  DOTNET_INSTALL_DIR: dotnet-install
+  DOTNET_ROOT: dotnet-install
   ENABLE_DIAGNOSTICS: true
   MSBUILD_VERBOSITY: normal
   #COREHOST_TRACE: 1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,6 +27,9 @@
     <NoWarn>$(NoWarn);Uno0001</NoWarn>
     <!-- TODO: Turn off sample pages needing samples for now, for initial commit -->
     <NoWarn>$(NoWarn);TKSMPL0014;</NoWarn> 
+
+    <!-- See https://github.com/CommunityToolkit/Windows/pull/567#issuecomment-2498739244 -->
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <Import Project="Windows.Toolkit.Common.props" />


### PR DESCRIPTION
This PR attempts to fix the ongoing CI errors caused by GitHub Actions updating the image to include net9.0 unexpectedly. 

This setup forces only the specified dotnet version to be available when `dotnet --list-sdks` is run, avoiding the errors caused by the introduction of dotnet 9 and unblocking us while we work to resolve them in https://github.com/CommunityToolkit/Windows/pull/563.  