### PR TITLE
Improvements to DispatcherQueueTimer.Debounce extension

### DIFF
--- a/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml
+++ b/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml
@@ -1,14 +1,14 @@
-<Page
-    x:Class="ExtensionsExperiment.Samples.DispatcherQueueExtensions.KeyboardDebounceSample"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+<Page x:Class="ExtensionsExperiment.Samples.DispatcherQueueExtensions.KeyboardDebounceSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d">
 
     <StackPanel Spacing="8">
-        <TextBox PlaceholderText="Type here..." TextChanged="TextBox_TextChanged"/>
-        <TextBlock x:Name="ResultText"/>
+        <TextBox PlaceholderText="Type here..."
+                 TextChanged="TextBox_TextChanged" />
+        <TextBlock x:Name="ResultText" />
     </StackPanel>
 </Page>

--- a/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml
+++ b/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml
@@ -1,0 +1,14 @@
+<Page
+    x:Class="ExtensionsExperiment.Samples.DispatcherQueueExtensions.KeyboardDebounceSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel Spacing="8">
+        <TextBox PlaceholderText="Type here..." TextChanged="TextBox_TextChanged"/>
+        <TextBlock x:Name="ResultText"/>
+    </StackPanel>
+</Page>

--- a/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml.cs
+++ b/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml.cs
@@ -26,20 +26,17 @@ public sealed partial class KeyboardDebounceSample : Page
 
     private void TextBox_TextChanged(object sender, TextChangedEventArgs e)
     {
-        var interval = this.GeneratedPropertyMetadata?.FirstOrDefault(vm => vm.Name == "Interval")?.Value as double?;
-
-        if (sender is TextBox textBox && interval != null)
+        if (sender is TextBox textBox)
         {
             _debounceTimer.Debounce(() =>
                 {
                     ResultText.Text = textBox.Text;
                 },
                 //// i.e. if another keyboard press comes in within 120ms of the last, we'll wait before we fire off the request
-                interval: TimeSpan.FromMilliseconds(interval.Value),
+                interval: TimeSpan.FromMilliseconds(Interval),
                 //// If we're blanking out or the first character type, we'll start filtering immediately instead to appear more responsive.
                 //// We want to switch back to trailing as the user types more so that we still capture all the input.
                 immediate: textBox.Text.Length <= 1);
-
         }
     }
 }

--- a/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml.cs
+++ b/components/Extensions/samples/Dispatcher/KeyboardDebounceSample.xaml.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.WinUI;
+#if WINAPPSDK
+using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
+using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
+#else
+using DispatcherQueue = Windows.System.DispatcherQueue;
+using DispatcherQueueTimer = Windows.System.DispatcherQueueTimer;
+#endif
+
+namespace ExtensionsExperiment.Samples.DispatcherQueueExtensions;
+
+[ToolkitSample(id: nameof(KeyboardDebounceSample), "DispatcherQueueTimer Debounce Keyboard", description: "A sample for showing how to use the DispatcherQueueTimer Debounce extension to smooth keyboard input.")]
+[ToolkitSampleNumericOption("Interval", 120, 60, 240)]
+public sealed partial class KeyboardDebounceSample : Page
+{
+    public DispatcherQueueTimer _debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+    public KeyboardDebounceSample()
+    {
+        InitializeComponent();
+    }
+
+    private void TextBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        var interval = this.GeneratedPropertyMetadata?.FirstOrDefault(vm => vm.Name == "Interval")?.Value as double?;
+
+        if (sender is TextBox textBox && interval != null)
+        {
+            _debounceTimer.Debounce(() =>
+                {
+                    ResultText.Text = textBox.Text;
+                },
+                //// i.e. if another keyboard press comes in within 120ms of the last, we'll wait before we fire off the request
+                interval: TimeSpan.FromMilliseconds(interval.Value),
+                //// If we're blanking out or the first character type, we'll start filtering immediately instead to appear more responsive.
+                //// We want to switch back to trailing as the user types more so that we still capture all the input.
+                immediate: textBox.Text.Length <= 1);
+
+        }
+    }
+}

--- a/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml
+++ b/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml
@@ -1,0 +1,14 @@
+<Page
+    x:Class="ExtensionsExperiment.Samples.DispatcherQueueExtensions.MouseDebounceSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel Spacing="8">
+        <Button Click="Button_Click" Content="Click Me"/>
+        <TextBlock x:Name="ResultText"/>
+    </StackPanel>
+</Page>

--- a/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml
+++ b/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml
@@ -1,14 +1,14 @@
-<Page
-    x:Class="ExtensionsExperiment.Samples.DispatcherQueueExtensions.MouseDebounceSample"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+<Page x:Class="ExtensionsExperiment.Samples.DispatcherQueueExtensions.MouseDebounceSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d">
 
     <StackPanel Spacing="8">
-        <Button Click="Button_Click" Content="Click Me"/>
-        <TextBlock x:Name="ResultText"/>
+        <Button Click="Button_Click"
+                Content="Click Me" />
+        <TextBlock x:Name="ResultText" />
     </StackPanel>
 </Page>

--- a/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml.cs
+++ b/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.WinUI;
+#if WINAPPSDK
+using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
+using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
+#else
+using DispatcherQueue = Windows.System.DispatcherQueue;
+using DispatcherQueueTimer = Windows.System.DispatcherQueueTimer;
+#endif
+
+namespace ExtensionsExperiment.Samples.DispatcherQueueExtensions;
+
+[ToolkitSample(id: nameof(MouseDebounceSample), "DispatcherQueueTimer Debounce Mouse", description: "A sample for showing how to use the DispatcherQueueTimer Debounce extension to smooth mouse input.")]
+[ToolkitSampleNumericOption("Interval", 400, 300, 1000)]
+public sealed partial class MouseDebounceSample : Page
+{
+    public DispatcherQueueTimer _debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+    private int _count = 0;
+
+    public MouseDebounceSample()
+    {
+        InitializeComponent();
+    }
+
+    private void Button_Click(object sender, RoutedEventArgs e)
+    {
+        var interval = this.GeneratedPropertyMetadata?.FirstOrDefault(vm => vm.Name == "Interval")?.Value as double?;
+
+        if (interval != null)
+        {
+            _debounceTimer.Debounce(() =>
+                {
+                    ResultText.Text = $"You hit the button {++_count} times!";
+                },
+                interval: TimeSpan.FromMilliseconds(interval.Value),
+                // By being on the leading edge, we ignore inputs past the first for the duration of the interval
+                immediate: true);
+        }
+    }
+}

--- a/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml.cs
+++ b/components/Extensions/samples/Dispatcher/MouseDebounceSample.xaml.cs
@@ -28,17 +28,12 @@ public sealed partial class MouseDebounceSample : Page
 
     private void Button_Click(object sender, RoutedEventArgs e)
     {
-        var interval = this.GeneratedPropertyMetadata?.FirstOrDefault(vm => vm.Name == "Interval")?.Value as double?;
-
-        if (interval != null)
-        {
-            _debounceTimer.Debounce(() =>
-                {
-                    ResultText.Text = $"You hit the button {++_count} times!";
-                },
-                interval: TimeSpan.FromMilliseconds(interval.Value),
-                // By being on the leading edge, we ignore inputs past the first for the duration of the interval
-                immediate: true);
-        }
+        _debounceTimer.Debounce(() =>
+            {
+                ResultText.Text = $"You hit the button {++_count} times!";
+            },
+            interval: TimeSpan.FromMilliseconds(Interval),
+            // By being on the leading edge, we ignore inputs past the first for the duration of the interval
+            immediate: true);
     }
 }

--- a/components/Extensions/samples/DispatcherQueueTimerExtensions.md
+++ b/components/Extensions/samples/DispatcherQueueTimerExtensions.md
@@ -12,7 +12,9 @@ issue-id: 0
 icon: Assets/Extensions.png
 ---
 
-The `DispatcherQueueTimerExtensions` static class provides a collection of extensions methods for [`DispatcherQueueTimer`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.dispatching.dispatcherqueue) objects that make it easier to execute code on a specific UI thread at a specific time.
+The `DispatcherQueueTimerExtensions` static class provides an extension method for [`DispatcherQueueTimer`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.dispatching.dispatcherqueue) objects that make it easier to execute code on a specific UI thread at a specific time.
+
+The `DispatcherQueueTimerExtensions` provides a single extension method, `Debounce`. This is a standard technique used to rate-limit input from a user to not overload requests on an underlying service or query elsewhere.
 
 > [!WARNING]
 > You should exclusively use the `DispatcherQueueTimer` instance calling `Debounce` for the purposes of Debouncing one specific action/scenario only and not configure it for other additional uses.
@@ -22,9 +24,10 @@ For each sceario that you want to Debounce, you'll want to create a separate `Di
 > [!NOTE]
 > Using the `Debounce` method will set `DispatcherQueueTimer.IsRepeating` to `false` to ensure proper operation. Do not change this value.
 
-## Syntax
+> [!NOTE]
+> If additionally registering to the `DispatcherQueueTimer.Tick` event (uncommon), it will be raised in one of two ways: 1. For a trailing debounce, it will be raised alongside the requested Action passed to the Debounce method. 2. For a leading debounce, it will be raised when the cooldown has expired and another call to Debounce would result in running the action.
 
-The `DispatcherQueueTimerExtensions` static class currently exposes a single extension method, `Debounce`. This is a standard technique used to rate-limit input from a user to not overload requests on an underlying service of query elsewhere.
+## Syntax
 
 It can be used in a number of ways, but most simply like so as a keyboard limiter:
 

--- a/components/Extensions/samples/DispatcherQueueTimerExtensions.md
+++ b/components/Extensions/samples/DispatcherQueueTimerExtensions.md
@@ -19,7 +19,7 @@ The `DispatcherQueueTimerExtensions` provides a single extension method, `Deboun
 > [!WARNING]
 > You should exclusively use the `DispatcherQueueTimer` instance calling `Debounce` for the purposes of Debouncing one specific action/scenario only and not configure it for other additional uses.
 
-For each sceario that you want to Debounce, you'll want to create a separate `DispatcherQueueTimer` instance to track that specific scenario. For instance, if the below samples were both within your application. You'd need two separate timers to track debouncing both scenarios. One for the keyboard input, and a different one for the mouse input.
+For each scenario that you want to Debounce, you'll want to create a separate `DispatcherQueueTimer` instance to track that specific scenario. For instance, if the below samples were both within your application. You'd need two separate timers to track debouncing both scenarios. One for the keyboard input, and a different one for the mouse input.
 
 > [!NOTE]
 > Using the `Debounce` method will set `DispatcherQueueTimer.IsRepeating` to `false` to ensure proper operation. Do not change this value.

--- a/components/Extensions/samples/DispatcherQueueTimerExtensions.md
+++ b/components/Extensions/samples/DispatcherQueueTimerExtensions.md
@@ -1,0 +1,27 @@
+---
+title: DispatcherQueueTimerExtensions
+author: michael-hawker
+description: Helpers for executing code at specific times on a UI thread through a DispatcherQueue instance with a DispatcherQueueTimer.
+keywords: dispatcher, dispatcherqueue, DispatcherHelper, DispatcherQueueExtensions, DispatcherQueueTimer, DispatcherQueueTimerExtensions
+dev_langs:
+  - csharp
+category: Extensions
+subcategory: Miscellaneous
+discussion-id: 0
+issue-id: 0
+icon: Assets/Extensions.png
+---
+
+The `DispatcherQueueTimerExtensions` static class provides a collection of extensions methods for [`DispatcherQueueTimer`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.dispatching.dispatcherqueue) objects that make it easier to execute code on a specific UI thread at a specific time.
+
+## Syntax
+
+The `DispatcherQueueTimerExtensions` static class currently exposes a single extension method, `Debounce`. This is a standard technique used to rate-limit input from a user to not overload requests on an underlying service of query elsewhere.
+
+It can be used in a number of ways, but most simply like so:
+
+> [!SAMPLE KeyboardDebounceSample]
+
+## Examples
+
+You can find more examples in the [unit tests](https://github.com/CommunityToolkit/Windows/blob/rel/8.1.240916/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs).

--- a/components/Extensions/samples/DispatcherQueueTimerExtensions.md
+++ b/components/Extensions/samples/DispatcherQueueTimerExtensions.md
@@ -18,9 +18,13 @@ The `DispatcherQueueTimerExtensions` static class provides a collection of exten
 
 The `DispatcherQueueTimerExtensions` static class currently exposes a single extension method, `Debounce`. This is a standard technique used to rate-limit input from a user to not overload requests on an underlying service of query elsewhere.
 
-It can be used in a number of ways, but most simply like so:
+It can be used in a number of ways, but most simply like so as a keyboard limiter:
 
 > [!SAMPLE KeyboardDebounceSample]
+
+Or for preventing multiple inputs from occuring accidentally (e.g. ignoring a double/multi-click):
+
+> [!SAMPLE MouseDebounceSample]
 
 ## Examples
 

--- a/components/Extensions/samples/DispatcherQueueTimerExtensions.md
+++ b/components/Extensions/samples/DispatcherQueueTimerExtensions.md
@@ -14,6 +14,14 @@ icon: Assets/Extensions.png
 
 The `DispatcherQueueTimerExtensions` static class provides a collection of extensions methods for [`DispatcherQueueTimer`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.dispatching.dispatcherqueue) objects that make it easier to execute code on a specific UI thread at a specific time.
 
+> [!WARNING]
+> You should exclusively use the `DispatcherQueueTimer` instance calling `Debounce` for the purposes of Debouncing one specific action/scenario only and not configure it for other additional uses.
+
+For each sceario that you want to Debounce, you'll want to create a separate `DispatcherQueueTimer` instance to track that specific scenario. For instance, if the below samples were both within your application. You'd need two separate timers to track debouncing both scenarios. One for the keyboard input, and a different one for the mouse input.
+
+> [!NOTE]
+> Using the `Debounce` method will set `DispatcherQueueTimer.IsRepeating` to `false` to ensure proper operation. Do not change this value.
+
 ## Syntax
 
 The `DispatcherQueueTimerExtensions` static class currently exposes a single extension method, `Debounce`. This is a standard technique used to rate-limit input from a user to not overload requests on an underlying service of query elsewhere.

--- a/components/Extensions/src/Dispatcher/DispatcherQueueTimerExtensions.cs
+++ b/components/Extensions/src/Dispatcher/DispatcherQueueTimerExtensions.cs
@@ -19,7 +19,7 @@ namespace CommunityToolkit.WinUI;
 /// </summary>
 public static class DispatcherQueueTimerExtensions
 {
-    //// https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2
+    /// <inheritdoc cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey,TValue}" />
     private static ConditionalWeakTable<DispatcherQueueTimer, Action> _debounceInstances = new();
 
     /// <summary>

--- a/components/Extensions/src/Dispatcher/DispatcherQueueTimerExtensions.cs
+++ b/components/Extensions/src/Dispatcher/DispatcherQueueTimerExtensions.cs
@@ -20,7 +20,7 @@ public static class DispatcherQueueTimerExtensions
     private static ConcurrentDictionary<DispatcherQueueTimer, Action> _debounceInstances = new ConcurrentDictionary<DispatcherQueueTimer, Action>();
 
     /// <summary>
-    /// <para>Used to debounce (rate-limit) an event.  The action will be postponed and executed after the interval has elapsed.  At the end of the interval, the function will be called with the arguments that were passed most recently to the debounced function.</para>
+    /// <para>Used to debounce (rate-limit) an event.  The action will be postponed and executed after the interval has elapsed.  At the end of the interval, the function will be called with the arguments that were passed most recently to the debounced function. Useful for smoothing keyboard input, for instance.</para>
     /// <para>Use this method to control the timer instead of calling Start/Interval/Stop manually.</para>
     /// <para>A scheduled debounce can still be stopped by calling the stop method on the timer instance.</para>
     /// <para>Each timer can only have one debounced function limited at a time.</para>
@@ -28,14 +28,14 @@ public static class DispatcherQueueTimerExtensions
     /// <param name="timer">Timer instance, only one debounced function can be used per timer.</param>
     /// <param name="action">Action to execute at the end of the interval.</param>
     /// <param name="interval">Interval to wait before executing the action.</param>
-    /// <param name="immediate">Determines if the action execute on the leading edge instead of trailing edge.</param>
+    /// <param name="immediate">Determines if the action execute on the leading edge instead of trailing edge of the interval. Subsequent input will be ignored into the interval has completed. Useful for ignore extraneous extra input like multiple mouse clicks.</param>
     /// <example>
     /// <code>
     /// private DispatcherQueueTimer _typeTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
     ///
     /// _typeTimer.Debounce(async () =>
     ///     {
-    ///         // Only executes this code after 0.3 seconds have elapsed since last trigger.
+    ///         // Only executes code put here after 0.3 seconds have elapsed since last call to Debounce.
     ///     }, TimeSpan.FromSeconds(0.3));
     /// </code>
     /// </example>

--- a/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
+++ b/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
@@ -53,6 +53,45 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
     [TestCategory("DispatcherQueueTimerExtensions")]
     [UIThreadTestMethod]
+    public async Task DispatcherQueueTimer_Debounce_Trailing_Stop()
+    {
+        var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        var triggeredCount = 0;
+        string? triggeredValue = null;
+
+        var value = "He";
+        debounceTimer.Debounce(
+            () =>
+            {
+                triggeredCount++;
+                triggeredValue = value;
+            },
+            TimeSpan.FromMilliseconds(60));
+
+        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
+        Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
+
+        await Task.Delay(TimeSpan.FromMilliseconds(20));
+
+        // Stop the timer before it would fire.
+        debounceTimer.Stop();
+
+        Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
+        Assert.IsNull(triggeredValue, "Expected result should be no value set.");
+        Assert.AreEqual(0, triggeredCount, "Expected not to have code run.");
+
+        // Wait until timer would have fired
+        await Task.Delay(TimeSpan.FromMilliseconds(60));
+
+        Assert.AreEqual(false, debounceTimer.IsRunning, "Expected the timer to remain stopped.");
+        Assert.IsNull(triggeredValue, "Expected result should still be no value set.");
+        Assert.AreEqual(0, triggeredCount, "Expected not to have code run still.");
+    }
+
+    [TestCategory("DispatcherQueueTimerExtensions")]
+    [UIThreadTestMethod]
     public async Task DispatcherQueueTimer_Debounce_Trailing_Interrupt()
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();

--- a/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
+++ b/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
@@ -83,6 +83,8 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
             TimeSpan.FromMilliseconds(60));
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
+        Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
 
         await Task.Delay(TimeSpan.FromMilliseconds(110));
 
@@ -112,8 +114,17 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(1, triggeredCount, "Function should have run right away.");
         Assert.AreEqual(value, triggeredValue, "Should have expected immediate set of value");
+
+        await Task.Delay(TimeSpan.FromMilliseconds(80));
+
+        Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
     }
 
+    /// <summary>
+    /// Tests the immediate mode of the Debounce function ignoring subsequent inputs that come after the first within the specified time window.
+    /// For instance, this could be useful to ignore extra multiple clicks on a button, but immediately start processing upon the first click.
+    /// </summary>
+    /// <returns></returns>
     [TestCategory("DispatcherQueueTimerExtensions")]
     [UIThreadTestMethod]
     public async Task DispatcherQueueTimer_Debounce_Immediate_Interrupt()
@@ -143,14 +154,85 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
                 triggeredCount++;
                 triggeredValue = value2;
             },
-            TimeSpan.FromMilliseconds(60));
+            TimeSpan.FromMilliseconds(60), true); // Ensure we're interrupting with immediate again
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
+        Assert.AreEqual(1, triggeredCount, "2nd request coming within first period should have been ignored.");
+        Assert.AreEqual(value, triggeredValue, "Value shouldn't have changed from 2nd request within time bound.");
 
         await Task.Delay(TimeSpan.FromMilliseconds(110));
 
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
-        Assert.AreEqual(value2, triggeredValue, "Expected to execute the last action.");
-        Assert.AreEqual(2, triggeredCount, "Expected to postpone execution.");
+        Assert.AreEqual(value, triggeredValue, "Expected to execute only the first action.");
+        Assert.AreEqual(1, triggeredCount, "Expected 2nd request to be ignored.");
+    }
+
+    /// <summary>
+    /// Tests where we start with immediately processing a delay, but then want to switch to processing after.
+    /// For instance, maybe we want to ensure we start processing the first letter of a search query to filter initial results.
+    /// But then later want to delay and wait to execute until all the query string is available.
+    /// </summary>
+    /// <returns></returns>
+    [TestCategory("DispatcherQueueTimerExtensions")]
+    [UIThreadTestMethod]
+    public async Task DispatcherQueueTimer_Debounce_Leading_Switch_Trailing_Interrupt_Twice()
+    {
+        var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        var triggeredCount = 0;
+        string? triggeredValue = null;
+
+        var value = "H";
+        debounceTimer.Debounce(
+            () =>
+            {
+                triggeredCount++;
+                triggeredValue = value;
+            },
+            TimeSpan.FromMilliseconds(100), true); // Start off right away
+
+        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
+        Assert.AreEqual(1, triggeredCount, "Function should have run right away.");
+        Assert.AreEqual(value, triggeredValue, "Function should have set value immediately.");
+
+        // Pragmatic pause
+        await Task.Delay(TimeSpan.FromMilliseconds(30));
+
+        // Now interrupt with more data two times.
+        var value2 = "Hel";
+        debounceTimer.Debounce(
+            () =>
+            {
+                triggeredCount++;
+                triggeredValue = value2;
+            },
+            TimeSpan.FromMilliseconds(100), false); // We want to ensure we catch the latest data now
+
+        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected timer to still to be running.");
+        Assert.AreEqual(1, triggeredCount, "Function should now haven't run again yet.");
+        Assert.AreEqual(value, triggeredValue, "Function should still be the initial value");
+
+        // Pragmatic pause again
+        await Task.Delay(TimeSpan.FromMilliseconds(30));
+
+        var value3 = "Hello";
+        debounceTimer.Debounce(
+            () =>
+            {
+                triggeredCount++;
+                triggeredValue = value3;
+            },
+            TimeSpan.FromMilliseconds(100), false); // We want to ensure we catch the latest data now
+
+        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected timer to still to be running.");
+        Assert.AreEqual(1, triggeredCount, "Function should still now haven't run again yet.");
+        Assert.AreEqual(value, triggeredValue, "Function should still be the initial value x2");
+
+        // Wait to where the timer should have fired and is done
+        await Task.Delay(TimeSpan.FromMilliseconds(120));
+
+        Assert.AreEqual(false, debounceTimer.IsRunning, "Expected timer to stopped at trailing edge to execute latest result.");
+        Assert.AreEqual(value3, triggeredValue, "Expected value to now be the last value provided.");
+        Assert.AreEqual(2, triggeredCount, "Expected to interrupt execution of 2nd request.");
     }
 }

--- a/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
+++ b/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
@@ -84,7 +84,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
             },
             TimeSpan.FromMilliseconds(60));
 
-        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
+        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected timer to be running.");
         Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
         Assert.AreEqual(0, customTriggeredCount, "Custom Function shouldn't have run yet.");
         Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
@@ -198,9 +198,9 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
     /// <summary>
     /// Tests the immediate mode of the Debounce function ignoring subsequent inputs that come after the first within the specified time window.
+    /// <para />
     /// For instance, this could be useful to ignore extra multiple clicks on a button, but immediately start processing upon the first click.
     /// </summary>
-    /// <returns></returns>
     [TestCategory("DispatcherQueueTimerExtensions")]
     [UIThreadTestMethod]
     public async Task DispatcherQueueTimer_Debounce_Immediate_Interrupt()
@@ -256,10 +256,10 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
     /// <summary>
     /// Tests the scenario where we flip from wanting trailing to leading edge invocation.
+    /// <para />
     /// For instance, this could be for a case where a user has cleared the textbox, so you
     /// want to immediately return new results vs. waiting for further input.
     /// </summary>
-    /// <returns></returns>
     [TestCategory("DispatcherQueueTimerExtensions")]
     [UIThreadTestMethod]
     public async Task DispatcherQueueTimer_Debounce_Trailing_Switch_Leading_Interrupt()
@@ -318,11 +318,10 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     }
 
     /// <summary>
-    /// Tests where we start with immediately processing a delay, but then want to switch to processing after.
-    /// For instance, maybe we want to ensure we start processing the first letter of a search query to filter initial results.
-    /// But then later want to delay and wait to execute until all the query string is available.
+    /// Tests where we start with immediately processing a delay, then switch to processing after.
+    /// <para />
+    /// For instance, maybe we want to ensure we start processing the first letter of a search query to filter initial results. Then later, we might want to delay and wait to execute until all the query string is available.
     /// </summary>
-    /// <returns></returns>
     [TestCategory("DispatcherQueueTimerExtensions")]
     [UIThreadTestMethod]
     public async Task DispatcherQueueTimer_Debounce_Leading_Switch_Trailing_Interrupt_Twice()

--- a/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
+++ b/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
@@ -27,6 +27,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 
+        // Test custom event handler too
+        var customTriggeredCount = 0;
+        debounceTimer.Tick += (s, o) =>
+        {
+            customTriggeredCount++;
+        };
+
         var triggeredCount = 0;
         string? triggeredValue = null;
 
@@ -41,6 +48,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function shouldn't have run yet.");
         Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
 
         await Task.Delay(TimeSpan.FromMilliseconds(80));
@@ -48,6 +56,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
         Assert.AreEqual(value, triggeredValue, "Expected result to be set.");
         Assert.AreEqual(1, triggeredCount, "Expected to run once.");
+        Assert.AreEqual(1, customTriggeredCount, "Custom Function should have run once.");
     }
 
     [TestCategory("DispatcherQueueTimerExtensions")]
@@ -56,6 +65,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 
+        // Test custom event handler too
+        var customTriggeredCount = 0;
+        debounceTimer.Tick += (s, o) =>
+        {
+            customTriggeredCount++;
+        };
+
         var triggeredCount = 0;
         string? triggeredValue = null;
 
@@ -70,6 +86,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function shouldn't have run yet.");
         Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
 
         await Task.Delay(TimeSpan.FromMilliseconds(20));
@@ -80,6 +97,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
         Assert.IsNull(triggeredValue, "Expected result should be no value set.");
         Assert.AreEqual(0, triggeredCount, "Expected not to have code run.");
+        Assert.AreEqual(0, customTriggeredCount, "Expected not to have custom code run.");
 
         // Wait until timer would have fired
         await Task.Delay(TimeSpan.FromMilliseconds(60));
@@ -87,6 +105,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected the timer to remain stopped.");
         Assert.IsNull(triggeredValue, "Expected result should still be no value set.");
         Assert.AreEqual(0, triggeredCount, "Expected not to have code run still.");
+        Assert.AreEqual(0, customTriggeredCount, "Expected not to have custom code run still.");
     }
 
     [TestCategory("DispatcherQueueTimerExtensions")]
@@ -94,6 +113,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     public async Task DispatcherQueueTimer_Debounce_Trailing_Interrupt()
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        // Test custom event handler too
+        var customTriggeredCount = 0;
+        debounceTimer.Tick += (s, o) =>
+        {
+            customTriggeredCount++;
+        };
 
         var triggeredCount = 0;
         string? triggeredValue = null;
@@ -109,6 +135,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function shouldn't have run yet.");
         Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
 
         var value2 = "Hello";
@@ -122,6 +149,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function shouldn't have run yet.");
         Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
 
         await Task.Delay(TimeSpan.FromMilliseconds(110));
@@ -129,6 +157,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
         Assert.AreEqual(value2, triggeredValue, "Expected to execute the last action.");
         Assert.AreEqual(1, triggeredCount, "Expected to postpone execution.");
+        Assert.AreEqual(1, customTriggeredCount, "Expected to postpone execution of custom event handler.");
     }
 
     [TestCategory("DispatcherQueueTimerExtensions")]
@@ -136,6 +165,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     public async Task DispatcherQueueTimer_Debounce_Immediate()
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        // Test custom event handler too
+        var customTriggeredCount = 0;
+        debounceTimer.Tick += (s, o) =>
+        {
+            customTriggeredCount++;
+        };
 
         var triggeredCount = 0;
         string? triggeredValue = null;
@@ -151,11 +187,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(1, triggeredCount, "Function should have run right away.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function won't have run as cooldown hasn't elapsed.");
         Assert.AreEqual(value, triggeredValue, "Should have expected immediate set of value");
 
         await Task.Delay(TimeSpan.FromMilliseconds(80));
 
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
+        Assert.AreEqual(1, customTriggeredCount, "Custom Function should have run now that cooldown expired.");
     }
 
     /// <summary>
@@ -169,6 +207,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 
+        // Test custom event handler too
+        var customTriggeredCount = 0;
+        debounceTimer.Tick += (s, o) =>
+        {
+            customTriggeredCount++;
+        };
+
         var triggeredCount = 0;
         string? triggeredValue = null;
 
@@ -183,6 +228,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(1, triggeredCount, "Function should have run right away.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function should not have run as cooldown hasn't expired.");
         Assert.AreEqual(value, triggeredValue, "Should have expected immediate set of value");
 
         var value2 = "Hello";
@@ -196,17 +242,20 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(1, triggeredCount, "2nd request coming within first period should have been ignored.");
+        Assert.AreEqual(0, customTriggeredCount, "Cooldown should be reset, so we still shouldn't have fired Tick.");
         Assert.AreEqual(value, triggeredValue, "Value shouldn't have changed from 2nd request within time bound.");
 
+        // Wait for cooldown to expire
         await Task.Delay(TimeSpan.FromMilliseconds(110));
 
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
         Assert.AreEqual(value, triggeredValue, "Expected to execute only the first action.");
         Assert.AreEqual(1, triggeredCount, "Expected 2nd request to be ignored.");
+        Assert.AreEqual(1, customTriggeredCount, "Custom should have run now that cooldown expired.");
     }
 
     /// <summary>
-    /// Tests the scenario where we flip from wanting trailing to leading edge invocaton.
+    /// Tests the scenario where we flip from wanting trailing to leading edge invocation.
     /// For instance, this could be for a case where a user has cleared the textbox, so you
     /// want to immediately return new results vs. waiting for further input.
     /// </summary>
@@ -216,6 +265,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     public async Task DispatcherQueueTimer_Debounce_Trailing_Switch_Leading_Interrupt()
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        // Test custom event handler too
+        var customTriggeredCount = 0;
+        debounceTimer.Tick += (s, o) =>
+        {
+            customTriggeredCount++;
+        };
 
         var triggeredCount = 0;
         string? triggeredValue = null;
@@ -234,6 +290,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function shouldn't have run yet.");
         Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
 
         // Now interrupt with a scenario we want processed immediately, i.e. user started typing something new
@@ -248,6 +305,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected timer should still be running.");
         Assert.AreEqual(1, triggeredCount, "Function should now have run immediately.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function still shouldn't have run yet.");
         Assert.AreEqual(value2, triggeredValue, "Function should have set value to 'He'");
 
         // Wait to where all should be done
@@ -255,7 +313,8 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
         Assert.AreEqual(value2, triggeredValue, "Expected value to remain the same.");
-        Assert.AreEqual(1, triggeredCount, "Expected to interrupt execution and ignore initial queued exectution.");
+        Assert.AreEqual(1, triggeredCount, "Expected to interrupt execution and ignore initial queued execution.");
+        Assert.AreEqual(1, customTriggeredCount, "Custom function should have run once at end of leading cooldown.");
     }
 
     /// <summary>
@@ -269,6 +328,13 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
     public async Task DispatcherQueueTimer_Debounce_Leading_Switch_Trailing_Interrupt_Twice()
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        // Test custom event handler too
+        var customTriggeredCount = 0;
+        debounceTimer.Tick += (s, o) =>
+        {
+            customTriggeredCount++;
+        };
 
         var triggeredCount = 0;
         string? triggeredValue = null;
@@ -284,6 +350,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
         Assert.AreEqual(1, triggeredCount, "Function should have run right away.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function should not run right away on leading.");
         Assert.AreEqual(value, triggeredValue, "Function should have set value immediately.");
 
         // Pragmatic pause
@@ -301,6 +368,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected timer to still to be running.");
         Assert.AreEqual(1, triggeredCount, "Function should now haven't run again yet.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function should not run right away on switch to trailing either.");
         Assert.AreEqual(value, triggeredValue, "Function should still be the initial value");
 
         // Pragmatic pause again
@@ -317,6 +385,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 
         Assert.AreEqual(true, debounceTimer.IsRunning, "Expected timer to still to be running.");
         Assert.AreEqual(1, triggeredCount, "Function should still now haven't run again yet.");
+        Assert.AreEqual(0, customTriggeredCount, "Custom Function should not run yet, as not enough time passed.");
         Assert.AreEqual(value, triggeredValue, "Function should still be the initial value x2");
 
         // Wait to where the timer should have fired and is done
@@ -325,6 +394,7 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected timer to stopped at trailing edge to execute latest result.");
         Assert.AreEqual(value3, triggeredValue, "Expected value to now be the last value provided.");
         Assert.AreEqual(2, triggeredCount, "Expected to interrupt execution of 2nd request.");
+        Assert.AreEqual(1, customTriggeredCount, "Custom Function should have run once at end of trailing debounce.");
     }
 
     [TestCategory("DispatcherQueueTimerExtensions")]

--- a/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
+++ b/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
@@ -24,7 +24,36 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
 {
     [TestCategory("DispatcherQueueTimerExtensions")]
     [UIThreadTestMethod]
-    public async Task DispatcherQueueTimer_Debounce_Interrupt()
+    public async Task DispatcherQueueTimer_Debounce_Trailing()
+    {
+        var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        var triggeredCount = 0;
+        string? triggeredValue = null;
+
+        var value = "He";
+        debounceTimer.Debounce(
+            () =>
+            {
+                triggeredCount++;
+                triggeredValue = value;
+            },
+            TimeSpan.FromMilliseconds(60));
+
+        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
+        Assert.AreEqual(0, triggeredCount, "Function shouldn't have run yet.");
+        Assert.IsNull(triggeredValue, "Function shouldn't have run yet.");
+
+        await Task.Delay(TimeSpan.FromMilliseconds(80));
+
+        Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
+        Assert.AreEqual(value, triggeredValue, "Expected result to be set.");
+        Assert.AreEqual(1, triggeredCount, "Expected to run once.");
+    }
+
+    [TestCategory("DispatcherQueueTimerExtensions")]
+    [UIThreadTestMethod]
+    public async Task DispatcherQueueTimer_Debounce_Trailing_Interrupt()
     {
         var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 
@@ -60,6 +89,29 @@ public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase
         Assert.AreEqual(false, debounceTimer.IsRunning, "Expected to stop the timer.");
         Assert.AreEqual(value2, triggeredValue, "Expected to execute the last action.");
         Assert.AreEqual(1, triggeredCount, "Expected to postpone execution.");
+    }
+
+    [TestCategory("DispatcherQueueTimerExtensions")]
+    [UIThreadTestMethod]
+    public async Task DispatcherQueueTimer_Debounce_Immediate()
+    {
+        var debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+        var triggeredCount = 0;
+        string? triggeredValue = null;
+
+        var value = "He";
+        debounceTimer.Debounce(
+            () =>
+            {
+                triggeredCount++;
+                triggeredValue = value;
+            },
+            TimeSpan.FromMilliseconds(60), true);
+
+        Assert.AreEqual(true, debounceTimer.IsRunning, "Expected time to be running.");
+        Assert.AreEqual(1, triggeredCount, "Function should have run right away.");
+        Assert.AreEqual(value, triggeredValue, "Should have expected immediate set of value");
     }
 
     [TestCategory("DispatcherQueueTimerExtensions")]


### PR DESCRIPTION
## Fixes #143 (among other things not filed)

This PR does a lot of clean-up for the Debounce function, it adds:

- More tests for a variety of scenarios for using Debounce
- Adds Samples for Keyboard and Mouse debouncing using these APIs and improvements
- Fixes the issue when switching the same timer from trailing to leading mode where the requested action would not fire immediately.
- Switch to using ConditionalWeakTable instead of ConcurrentDictionary to ensure we don't capture the DispatcherQueueTimer
- Fixes #143 the issue of immediate not working well by setting `IsRepeating` on the timer to false during initialization. FYI @huynhsontung - This shouldn't effect your own registrations to the `Tick` method, if you're using Debounce, there should only be the one timer per Debounce, and your `Tick` should be called whenever the Debounce fires.

## PR Type

What kind of change does this PR introduce?

- Bugfix 
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Switching from trailing to leading edge of Debounce wouldn't fire immediately.

Using Debounce would hold reference to DispatcherQueueTimer object.

## What is the new behavior?

Switching from trailing to leading edge now fires immediately.

Using Debounce doesn't hold a reference to the DispatcherQueuTimer object

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [ ] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [ ] Based off latest main branch of toolkit
- [ ] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [ ] Header has been added to all new source files
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

- [x] Add test(s) based on #143 for having custom `Tick` handler as well in user code.
- [x] Document the need for Debounces to have dedicated timers, as well as the behavior of setting `IsRepeating` to false on the timer.
  - It was never intended to support any sort of repeating ticked event in combination with the debouncer, that may be possible, but is outside of the scope of what we intend to do here. In the future, I could see a "repeating" parameter added which controls that in the future maybe - if we define the expected behavior, but for the default intended behavior now `IsRepeating` should be and remain `false`.
