### PR TITLE
Fix solution generation via default .bat

### DIFF
--- a/GenerateAllSolution.bat
+++ b/GenerateAllSolution.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
 SET "MultiTargets=%1"
-IF "%MultiTargets%"=="" SET "MultiTargets=all"
+IF "%MultiTargets%"=="" SET "MultiTargets=uwp,wasdk,wasm"
 
 powershell .\tooling\GenerateAllSolution.ps1 -MultiTargets %MultiTargets%


### PR DESCRIPTION
This PR fixes solution generation issues when end users open the default `GenerateAllSolution.bat` by only enabling the default minimum MultiTargets (uwp, wasdk, wasm).  

The underlying issue affects solution generation when `android`, `ios` or `macos` MultiTargets are requested or enabled. These targets don't have corresponding gallery or test heads that can be built, so they're unnecessary and have been disabled. This does not affect our ability to build these targets in CI.

Issue also reported in the [Windows App Community Discord](https://discord.com/channels/372137812037730304/669640275500466197/1314138588232945695).