### PR TITLE
Enable .NET 8 for uwp MultiTarget, upgrade packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/devcontainers/images/tree/main/src/dotnet for image choices
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:8.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:9.0
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		"args": {
 			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
 			// Append -bullseye or -focal to pin to an OS version.
-			"VARIANT": "8.0",
+			"VARIANT": "9.0",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
 
       # Build and pack component nupkg
       - name: Build and pack component packages
-        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release -AdditionalProperties @{ "Platform" = "`"x86,x64,arm64`"" }
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
 
       # Push Pull Request Packages to our DevOps Artifacts Feed (see nuget.config)
       - name: Push Pull Request Packages (if not fork)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
 
       # Build and pack component nupkg
       - name: Build and pack component packages
-        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release -AdditionalProperties @{ "Platforms" = "`"x86;x64;arm64;`"" }
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release -AdditionalProperties @{ "Platform" = "`"x86,x64,arm64`"" }
 
       # Push Pull Request Packages to our DevOps Artifacts Feed (see nuget.config)
       - name: Push Pull Request Packages (if not fork)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
   # Build both Uno.UI/WinUI2/UWP and Uno.WinUI/WinUI3/WindowsAppSDK versions of our packages using a matrix
   build:
     needs: [Xaml-Style-Check]
-    runs-on: windows-latest-large
+    runs-on: windows-latest
 
     # See https://docs.github.com/actions/using-jobs/using-a-matrix-for-your-jobs
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,7 @@ on:
   merge_group:
 
 env:
-  DOTNET_VERSION: ${{ '8.0.201' }}
-  DOTNET_INSTALL_DIR: dotnet-install
-  DOTNET_ROOT: dotnet-install
+  DOTNET_VERSION: ${{ '9.0.100' }}
   ENABLE_DIAGNOSTICS: true
   MSBUILD_VERBOSITY: normal
   #COREHOST_TRACE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
 
       # Build and pack component nupkg
       - name: Build and pack component packages
-        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release -AdditionalProperties @{ "Platforms" = "`"x86;x64;arm64;`"" }
 
       # Push Pull Request Packages to our DevOps Artifacts Feed (see nuget.config)
       - name: Push Pull Request Packages (if not fork)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
   merge_group:
 
 env:
-  DOTNET_VERSION: ${{ '9.0.100' }}
+  DOTNET_VERSION: ${{ '9.0.x' }}
   ENABLE_DIAGNOSTICS: true
   MSBUILD_VERBOSITY: normal
   #COREHOST_TRACE: 1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,17 @@
 
     <!-- See https://github.com/CommunityToolkit/Windows/pull/567#issuecomment-2498739244 -->
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);TKSMPL0014;</NoWarn>
+
+    <!--
+      Suppress 'error CsWinRT1028: Class implements WinRT interfaces but isn't marked partial. ' for generated XamlMetaDataProvider.g.cs.
+      Fix is expected to arrive in prerelease1 of Microsoft.WindowsAppSdk 1.6.
+      Internal tracking: https://microsoft.visualstudio.com/OS/_workitems/edit/52541822/
+
+      Notice: This suppression affects CsWinRT1028 for all generated and non-generated code.
+        Disable to check non-generated code for CsWinRT1028.
+     -->
+    <NoWarn>$(NoWarn);CsWinRT1028;</NoWarn>    
   </PropertyGroup>
 
   <Import Project="Windows.Toolkit.Common.props" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,16 +31,6 @@
     <!-- See https://github.com/CommunityToolkit/Windows/pull/567#issuecomment-2498739244 -->
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
     <NoWarn>$(NoWarn);TKSMPL0014;</NoWarn>
-
-    <!--
-      Suppress 'error CsWinRT1028: Class implements WinRT interfaces but isn't marked partial. ' for generated XamlMetaDataProvider.g.cs.
-      Fix is expected to arrive in prerelease1 of Microsoft.WindowsAppSdk 1.6.
-      Internal tracking: https://microsoft.visualstudio.com/OS/_workitems/edit/52541822/
-
-      Notice: This suppression affects CsWinRT1028 for all generated and non-generated code.
-        Disable to check non-generated code for CsWinRT1028.
-     -->
-    <NoWarn>$(NoWarn);CsWinRT1028;</NoWarn>    
   </PropertyGroup>
 
   <Import Project="Windows.Toolkit.Common.props" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,8 @@
 <Project>
+  <ItemGroup>
+  <!-- Workaround for WebView2 on uap pulling in Microsoft.VCLibs.Desktop when it shouldn't -->
+    <SDKReference Remove="Microsoft.VCLibs.Desktop, Version=14.0" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.12.1" PrivateAssets="all" Pack="false" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.7.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.12.1" PrivateAssets="all" Pack="false" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/components/Behaviors/samples/InvokeActionsSample.xaml
+++ b/components/Behaviors/samples/InvokeActionsSample.xaml
@@ -5,7 +5,6 @@
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:local="using:BehaviorsExperiment.Samples"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -20,7 +19,7 @@
                               IsSequential="True">
                 <ani:StartAnimationActivity Animation="{Binding ElementName=FadeOutAnimation}" />
                 <ani:InvokeActionsActivity>
-                    <interactions:ChangePropertyAction PropertyName="Foreground"
+                    <interactivity:ChangePropertyAction PropertyName="Foreground"
                                                        TargetObject="{Binding ElementName=MyText}"
                                                        Value="Purple" />
                     <!--<mediaactions:PlaySoundAction Source="Assets/Llama.mp3"/>-->
@@ -53,12 +52,12 @@
         </TextBlock>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Click">
-                <interactions:ChangePropertyAction PropertyName="Foreground"
+            <interactivity:EventTriggerBehavior EventName="Click">
+                <interactivity:ChangePropertyAction PropertyName="Foreground"
                                                    TargetObject="{Binding ElementName=MyText}"
                                                    Value="White" />
                 <behaviors:StartAnimationAction Animation="{Binding ElementName=MoveAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Button>
 </Page>

--- a/components/Behaviors/samples/InvokeActionsSample.xaml
+++ b/components/Behaviors/samples/InvokeActionsSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="BehaviorsExperiment.Samples.InvokeActionsActivitySample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -20,8 +20,8 @@
                 <ani:StartAnimationActivity Animation="{Binding ElementName=FadeOutAnimation}" />
                 <ani:InvokeActionsActivity>
                     <interactivity:ChangePropertyAction PropertyName="Foreground"
-                                                       TargetObject="{Binding ElementName=MyText}"
-                                                       Value="Purple" />
+                                                        TargetObject="{Binding ElementName=MyText}"
+                                                        Value="Purple" />
                     <!--<mediaactions:PlaySoundAction Source="Assets/Llama.mp3"/>-->
                 </ani:InvokeActionsActivity>
                 <ani:StartAnimationActivity Animation="{Binding ElementName=FadeInAnimation}"
@@ -54,8 +54,8 @@
         <interactivity:Interaction.Behaviors>
             <interactivity:EventTriggerBehavior EventName="Click">
                 <interactivity:ChangePropertyAction PropertyName="Foreground"
-                                                   TargetObject="{Binding ElementName=MyText}"
-                                                   Value="White" />
+                                                    TargetObject="{Binding ElementName=MyText}"
+                                                    Value="White" />
                 <behaviors:StartAnimationAction Animation="{Binding ElementName=MoveAnimation}" />
             </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>

--- a/components/Behaviors/samples/KeyDownTriggerBehaviorSample.xaml
+++ b/components/Behaviors/samples/KeyDownTriggerBehaviorSample.xaml
@@ -10,7 +10,7 @@
             <interactivity:Interaction.Behaviors>
                 <behaviors:KeyDownTriggerBehavior Key="Enter">
                     <interactivity:CallMethodAction MethodName="IncrementCount"
-                                           TargetObject="{x:Bind}" />
+                                                    TargetObject="{x:Bind}" />
                 </behaviors:KeyDownTriggerBehavior>
             </interactivity:Interaction.Behaviors>
         </TextBox>

--- a/components/Behaviors/samples/KeyDownTriggerBehaviorSample.xaml
+++ b/components/Behaviors/samples/KeyDownTriggerBehaviorSample.xaml
@@ -2,7 +2,6 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:core="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity">
 
     <StackPanel MaxWidth="480"
@@ -10,7 +9,7 @@
         <TextBox PlaceholderText="Set the focus to this TextBox and press enter">
             <interactivity:Interaction.Behaviors>
                 <behaviors:KeyDownTriggerBehavior Key="Enter">
-                    <core:CallMethodAction MethodName="IncrementCount"
+                    <interactivity:CallMethodAction MethodName="IncrementCount"
                                            TargetObject="{x:Bind}" />
                 </behaviors:KeyDownTriggerBehavior>
             </interactivity:Interaction.Behaviors>

--- a/components/Behaviors/samples/NavigateToUriActionSample.xaml
+++ b/components/Behaviors/samples/NavigateToUriActionSample.xaml
@@ -2,14 +2,13 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:core="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity">
 
     <Button Content="Click to navigate">
         <interactivity:Interaction.Behaviors>
-            <core:EventTriggerBehavior EventName="Click">
+            <interactivity:EventTriggerBehavior EventName="Click">
                 <behaviors:NavigateToUriAction NavigateUri="https://aka.ms/toolkit/windows" />
-            </core:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Button>
 </Page>

--- a/components/Behaviors/samples/StartAnimationActivitySample.xaml
+++ b/components/Behaviors/samples/StartAnimationActivitySample.xaml
@@ -5,7 +5,6 @@
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:local="using:BehaviorsExperiment.Samples"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -55,9 +54,9 @@
         </Image>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Click">
+            <interactivity:EventTriggerBehavior EventName="Click">
                 <behaviors:StartAnimationAction Animation="{Binding ElementName=MoveAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Button>
 </Page>

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-local.240918"/>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-local.1126240956"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1"/>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-local2430.1330"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-preview1"/>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
@@ -21,7 +21,7 @@
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0-preview1" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0-preview2" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-local2430.1330"/>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-local.240918"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -16,7 +16,7 @@
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.1-uno.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.0-dev.17.g7c09b9114d" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
@@ -26,6 +26,6 @@
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.3.1-uno.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.0-dev.17.g7c09b9114d" />
   </ItemGroup>
 </Project>

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-local.1126240956"/>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0-preview1"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
@@ -21,7 +21,7 @@
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0-preview1" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->

--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -26,6 +26,6 @@
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.0-dev.17.g7c09b9114d" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI" Version="3.0.0-dev.17.g7c09b9114d" />
   </ItemGroup>
 </Project>

--- a/components/CameraPreview/samples/CameraPreviewSample.xaml.cs
+++ b/components/CameraPreview/samples/CameraPreviewSample.xaml.cs
@@ -92,7 +92,7 @@ public sealed partial class CameraPreviewSample : Page
         await CleanUpAsync();
     }
 
-    private async void Application_Suspending(object sender, SuspendingEventArgs e)
+    private async void Application_Suspending(object? sender, SuspendingEventArgs e)
     {
         if (Frame?.CurrentSourcePageType == typeof(CameraPreviewSample))
         {
@@ -102,7 +102,7 @@ public sealed partial class CameraPreviewSample : Page
         }
     }
 
-    private async void Application_Resuming(object sender, object e)
+    private async void Application_Resuming(object? sender, object e)
     {
         if (CameraPreviewControl != null)
         {
@@ -113,19 +113,19 @@ public sealed partial class CameraPreviewSample : Page
         }
     }
 
-    private void CameraPreviewControl_FrameArrived(object sender, FrameEventArgs e)
+    private void CameraPreviewControl_FrameArrived(object? sender, FrameEventArgs e)
     {
         _currentVideoFrame = e.VideoFrame;
     }
 
-    private void CameraPreviewControl_PreviewFailed(object sender, PreviewFailedEventArgs e)
+    private void CameraPreviewControl_PreviewFailed(object? sender, PreviewFailedEventArgs e)
     {
         ErrorBar.Message = e.Error;
         ErrorBar.IsOpen = true;
     }
 
 
-    private async void CaptureButton_Click(object sender, RoutedEventArgs e)
+    private async void CaptureButton_Click(object? sender, RoutedEventArgs e)
     {
         var softwareBitmap = _currentVideoFrame?.SoftwareBitmap;
 

--- a/components/ColorPicker/src/ColorPicker.cs
+++ b/components/ColorPicker/src/ColorPicker.cs
@@ -358,7 +358,7 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
         VisualStateManager.GoToState(this, (Truth(IsColorPaletteVisible, IsColorSpectrumVisible, IsColorChannelTextInputVisible) <= 1) ? "ColorPanelSelectorCollapsed" : "ColorPanelSelectorVisible", useTransitions);
     }
 
-    public static int Truth(params bool[] booleans)
+    private static int Truth(params bool[] booleans)
     {
         return booleans.Count(b => b);
     }

--- a/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
+++ b/components/ColorPicker/src/CommunityToolkit.WinUI.Controls.ColorPicker.csproj
@@ -30,4 +30,15 @@
       <_LayoutFile Remove="@(_LayoutFile)" Condition="$([System.String]::Copy(&quot;%(_LayoutFile.TargetPath)&quot;).StartsWith('CommunityToolkit.WinUI.Controls.Segmented\'))" />
     </ItemGroup>
   </Target>
+
+  <!-- 
+    Known platform issue
+    
+    error IL2059: Unrecognized value passed to the parameter 'type' of method
+    'System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(RuntimeTypeHandle)'.
+    It's not possible to guarantee the availability of the target static constructor. 
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn)IL2059;</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/components/Converters/src/ColorToDisplayNameConverter.cs
+++ b/components/Converters/src/ColorToDisplayNameConverter.cs
@@ -36,7 +36,7 @@ public partial class ColorToDisplayNameConverter : IValueConverter
 
 #if WINDOWS_UWP && NET8_0_OR_GREATER
         // Windows.UI.ColorHelper not yet supported on modern uwp.
-        return "Not supported"
+        return color.ToString();
 #elif WINUI2
         return Windows.UI.ColorHelper.ToDisplayName(color);
 #elif WINUI3

--- a/components/Converters/src/ColorToDisplayNameConverter.cs
+++ b/components/Converters/src/ColorToDisplayNameConverter.cs
@@ -36,6 +36,7 @@ public partial class ColorToDisplayNameConverter : IValueConverter
 
 #if WINDOWS_UWP && NET8_0_OR_GREATER
         // Windows.UI.ColorHelper not yet supported on modern uwp.
+        // Following advice from Sergio0694
         return color.ToString();
 #elif WINUI2
         return Windows.UI.ColorHelper.ToDisplayName(color);

--- a/components/Converters/src/ColorToDisplayNameConverter.cs
+++ b/components/Converters/src/ColorToDisplayNameConverter.cs
@@ -33,10 +33,10 @@ public partial class ColorToDisplayNameConverter : IValueConverter
             // Invalid color value provided
             return DependencyProperty.UnsetValue;
         }
-#if HAS_UNO
-        // ColorHelper.ToDisplayName not yet supported on Uno Platform.
-        // Track https://github.com/unoplatform/uno/issues/18004
-        return "Not supported";
+
+#if WINDOWS_UWP && NET8_0_OR_GREATER
+        // Windows.UI.ColorHelper not yet supported on modern uwp.
+        return "Not supported"
 #elif WINUI2
         return Windows.UI.ColorHelper.ToDisplayName(color);
 #elif WINUI3

--- a/components/Converters/src/ResourceNameToResourceStringConverter.cs
+++ b/components/Converters/src/ResourceNameToResourceStringConverter.cs
@@ -34,16 +34,16 @@ public sealed partial class ResourceNameToResourceStringConverter : IValueConver
     /// <returns>The string corresponding to the resource name.</returns>
     public object? Convert(object value, Type targetType, object parameter, string language)
     {
-        var valueAsString = value?.ToString();
-        if (valueAsString == null)
+        var stringValue = value?.ToString();
+        if (stringValue is null)
         {
             return string.Empty;
         }
 
 #if WINAPPSDK && !HAS_UNO
-        return _resourceManager.MainResourceMap.TryGetValue(valueAsString).ValueAsString;
+        return _resourceManager.MainResourceMap.TryGetValue(stringValue).ValueAsString;
 #else
-        return _resourceLoader.GetString(valueAsString);
+        return _resourceLoader.GetString(stringValue) ?? string.Empty;
 #endif
     }
 

--- a/components/Converters/src/ResourceNameToResourceStringConverter.cs
+++ b/components/Converters/src/ResourceNameToResourceStringConverter.cs
@@ -43,7 +43,7 @@ public sealed partial class ResourceNameToResourceStringConverter : IValueConver
 #if WINAPPSDK && !HAS_UNO
         return _resourceManager.MainResourceMap.TryGetValue(stringValue).ValueAsString;
 #else
-        return _resourceLoader.GetString(valueAsString);
+        return _resourceLoader.GetString(stringValue);
 #endif
     }
 

--- a/components/Converters/src/ResourceNameToResourceStringConverter.cs
+++ b/components/Converters/src/ResourceNameToResourceStringConverter.cs
@@ -43,7 +43,7 @@ public sealed partial class ResourceNameToResourceStringConverter : IValueConver
 #if WINAPPSDK && !HAS_UNO
         return _resourceManager.MainResourceMap.TryGetValue(stringValue).ValueAsString;
 #else
-        return _resourceLoader.GetString(stringValue) ?? string.Empty;
+        return _resourceLoader.GetString(valueAsString);
 #endif
     }
 

--- a/components/Converters/src/ResourceNameToResourceStringConverter.cs
+++ b/components/Converters/src/ResourceNameToResourceStringConverter.cs
@@ -32,17 +32,18 @@ public sealed partial class ResourceNameToResourceStringConverter : IValueConver
     /// <param name="parameter">Optional parameter. Not used.</param>
     /// <param name="language">The language of the conversion.</param>
     /// <returns>The string corresponding to the resource name.</returns>
-    public object Convert(object value, Type targetType, object parameter, string language)
+    public object? Convert(object value, Type targetType, object parameter, string language)
     {
-        if (value == null)
+        var valueAsString = value?.ToString();
+        if (valueAsString == null)
         {
             return string.Empty;
         }
 
 #if WINAPPSDK && !HAS_UNO
-        return _resourceManager.MainResourceMap.TryGetValue(value.ToString()).ValueAsString;
+        return _resourceManager.MainResourceMap.TryGetValue(valueAsString).ValueAsString;
 #else
-        return _resourceLoader.GetString(value.ToString());
+        return _resourceLoader.GetString(valueAsString);
 #endif
     }
 

--- a/components/Extensions/src/Markup/Abstract/TextIconExtension.cs
+++ b/components/Extensions/src/Markup/Abstract/TextIconExtension.cs
@@ -46,7 +46,7 @@ public abstract class TextIconExtension : MarkupExtension
     #if WINUI3
     public Windows.UI.Text.FontStyle FontStyle { get; set; } = Windows.UI.Text.FontStyle.Normal;
     #elif WINUI2
-    public Windows.UI.Text.FontWeight FontWeight { get; set; } = Windows.UI.Text.FontWeights.Normal;
+    public Windows.UI.Text.FontStyle FontStyle { get; set; } = Windows.UI.Text.FontStyle.Normal;
     #endif
 
     /// <summary>

--- a/components/Extensions/src/Markup/Abstract/TextIconExtension.cs
+++ b/components/Extensions/src/Markup/Abstract/TextIconExtension.cs
@@ -34,20 +34,12 @@ public abstract class TextIconExtension : MarkupExtension
     /// <summary>
     /// Gets or sets the thickness of the icon glyph.
     /// </summary>
-    #if WINUI3
-    public Windows.UI.Text.FontWeight FontWeight { get; set; } = Microsoft.UI.Text.FontWeights.Normal;
-    #elif WINUI2
     public Windows.UI.Text.FontWeight FontWeight { get; set; } = Windows.UI.Text.FontWeights.Normal;
-    #endif
 
     /// <summary>
     /// Gets or sets the font style for the icon glyph.
     /// </summary>
-    #if WINUI3
     public Windows.UI.Text.FontStyle FontStyle { get; set; } = Windows.UI.Text.FontStyle.Normal;
-    #elif WINUI2
-    public Windows.UI.Text.FontStyle FontStyle { get; set; } = Windows.UI.Text.FontStyle.Normal;
-    #endif
 
     /// <summary>
     /// Gets or sets the foreground <see cref="Brush"/> for the icon.

--- a/components/Extensions/src/Markup/Abstract/TextIconExtension.cs
+++ b/components/Extensions/src/Markup/Abstract/TextIconExtension.cs
@@ -34,12 +34,20 @@ public abstract class TextIconExtension : MarkupExtension
     /// <summary>
     /// Gets or sets the thickness of the icon glyph.
     /// </summary>
+    #if WINUI3
+    public Windows.UI.Text.FontWeight FontWeight { get; set; } = Microsoft.UI.Text.FontWeights.Normal;
+    #elif WINUI2
     public Windows.UI.Text.FontWeight FontWeight { get; set; } = Windows.UI.Text.FontWeights.Normal;
+    #endif
 
     /// <summary>
     /// Gets or sets the font style for the icon glyph.
     /// </summary>
+    #if WINUI3
     public Windows.UI.Text.FontStyle FontStyle { get; set; } = Windows.UI.Text.FontStyle.Normal;
+    #elif WINUI2
+    public Windows.UI.Text.FontWeight FontWeight { get; set; } = Windows.UI.Text.FontWeights.Normal;
+    #endif
 
     /// <summary>
     /// Gets or sets the foreground <see cref="Brush"/> for the icon.

--- a/components/Extensions/src/Text/StringExtensions.Localization.cs
+++ b/components/Extensions/src/Text/StringExtensions.Localization.cs
@@ -49,7 +49,7 @@ public static partial class StringExtensions
     /// You can retrieve this from a UIElement.UIContext, XamlRoot.UIContext (XamlIslands), or Window.UIContext.</param>
     /// <returns>string value for given resource or empty string if not found.</returns>
     ////[SupportedOSPlatform("Windows10.0.18362.0")]
-    public static string GetViewLocalized(this string resourceKey, UIContext? uiContext = null)
+    public static string? GetViewLocalized(this string resourceKey, UIContext? uiContext = null)
     {
         if (uiContext != null)
         {

--- a/components/Extensions/src/Text/StringExtensions.Localization.cs
+++ b/components/Extensions/src/Text/StringExtensions.Localization.cs
@@ -58,7 +58,7 @@ public static partial class StringExtensions
         }
         else
         {
-            return ResourceLoader.GetForCurrentView().GetString(resourceKey) ?? string.Empty;
+            return ResourceLoader.GetForCurrentView().GetString(resourceKey);
         }
     }
 #endif

--- a/components/Extensions/src/Text/StringExtensions.Localization.cs
+++ b/components/Extensions/src/Text/StringExtensions.Localization.cs
@@ -54,11 +54,11 @@ public static partial class StringExtensions
         if (uiContext != null)
         {
             var resourceLoader = ResourceLoader.GetForUIContext(uiContext);
-            return resourceLoader.GetString(resourceKey);
+            return resourceLoader?.GetString(resourceKey) ?? string.Empty;
         }
         else
         {
-            return ResourceLoader.GetForCurrentView().GetString(resourceKey);
+            return ResourceLoader.GetForCurrentView().GetString(resourceKey) ?? string.Empty;
         }
     }
 #endif

--- a/components/Extensions/src/Text/StringExtensions.Localization.cs
+++ b/components/Extensions/src/Text/StringExtensions.Localization.cs
@@ -54,7 +54,7 @@ public static partial class StringExtensions
         if (uiContext != null)
         {
             var resourceLoader = ResourceLoader.GetForUIContext(uiContext);
-            return resourceLoader?.GetString(resourceKey) ?? string.Empty;
+            return resourceLoader.GetString(resourceKey);
         }
         else
         {

--- a/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
+++ b/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
@@ -662,7 +662,9 @@ public static partial class FrameworkElementExtensions
     /// </summary>
     /// <param name="element">The parent element.</param>
     /// <returns>The retrieved content control, or <see langword="null"/> if not available.</returns>
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "This method is currently not safe for trimming, and annotations here wouldn't help.")]
+    #endif
     public static UIElement? GetContentControl(this FrameworkElement element)
     {
         Type type = element.GetType();

--- a/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
+++ b/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using CommunityToolkit.WinUI.Predicates;
-using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
@@ -96,7 +95,7 @@ public static partial class FrameworkElementExtensions
     /// <param name="element">The root element.</param>
     /// <param name="predicate">The predicatee to use to match the child nodes.</param>
     /// <returns>The child that was found, or <see langword="null"/>.</returns>
-    private static T? FindChild<T, TPredicate>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this FrameworkElement element, ref TPredicate predicate)
+    private static T? FindChild<T, TPredicate>(this FrameworkElement element, ref TPredicate predicate)
         where T : notnull, FrameworkElement
         where TPredicate : struct, IPredicate<T>
     {
@@ -663,7 +662,7 @@ public static partial class FrameworkElementExtensions
     /// </summary>
     /// <param name="element">The parent element.</param>
     /// <returns>The retrieved content control, or <see langword="null"/> if not available.</returns>
-    public static UIElement? GetContentControl([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this FrameworkElement element)
+    public static UIElement? GetContentControl(this FrameworkElement element)
     {
         Type type = element.GetType();
         TypeInfo? typeInfo = type.GetTypeInfo();

--- a/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
+++ b/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using CommunityToolkit.WinUI.Predicates;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
@@ -95,7 +96,7 @@ public static partial class FrameworkElementExtensions
     /// <param name="element">The root element.</param>
     /// <param name="predicate">The predicatee to use to match the child nodes.</param>
     /// <returns>The child that was found, or <see langword="null"/>.</returns>
-    private static T? FindChild<T, TPredicate>(this FrameworkElement element, ref TPredicate predicate)
+    private static T? FindChild<T, TPredicate>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this FrameworkElement element, ref TPredicate predicate)
         where T : notnull, FrameworkElement
         where TPredicate : struct, IPredicate<T>
     {
@@ -662,7 +663,7 @@ public static partial class FrameworkElementExtensions
     /// </summary>
     /// <param name="element">The parent element.</param>
     /// <returns>The retrieved content control, or <see langword="null"/> if not available.</returns>
-    public static UIElement? GetContentControl(this FrameworkElement element)
+    public static UIElement? GetContentControl([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this FrameworkElement element)
     {
         Type type = element.GetType();
         TypeInfo? typeInfo = type.GetTypeInfo();

--- a/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
+++ b/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
@@ -662,6 +662,7 @@ public static partial class FrameworkElementExtensions
     /// </summary>
     /// <param name="element">The parent element.</param>
     /// <returns>The retrieved content control, or <see langword="null"/> if not available.</returns>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "This method is currently not safe for trimming, and annotations here wouldn't help.")]
     public static UIElement? GetContentControl(this FrameworkElement element)
     {
         Type type = element.GetType();

--- a/components/ImageCropper/src/ImageCropper.Helpers.cs
+++ b/components/ImageCropper/src/ImageCropper.Helpers.cs
@@ -36,7 +36,20 @@ public partial class ImageCropper
         using (var sourceStream = writeableBitmap.PixelBuffer.AsStream())
         {
             var buffer = new byte[sourceStream.Length];
-            await sourceStream.ReadAsync(buffer, 0, buffer.Length);
+            var pos = 0;
+
+            while (pos < buffer.Length)
+            {
+                var remaining = buffer.Length - pos;
+                var read = await sourceStream.ReadAsync(buffer, pos, remaining);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                pos += read;
+            }
+
             var bitmapEncoder = await BitmapEncoder.CreateAsync(GetEncoderId(bitmapFileFormat), stream);
             bitmapEncoder.SetPixelData(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied, (uint)writeableBitmap.PixelWidth, (uint)writeableBitmap.PixelHeight, 96.0, 96.0, buffer);
             bitmapEncoder.BitmapTransform.Bounds = new BitmapBounds

--- a/components/Media/samples/BlurEffectAnimationSample.xaml
+++ b/components/Media/samples/BlurEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -38,9 +37,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind BlurAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 </Page>

--- a/components/Media/samples/ColorEffectAnimationSample.xaml
+++ b/components/Media/samples/ColorEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -38,9 +37,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind ColorAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 

--- a/components/Media/samples/CrossFadeEffectAnimationSample.xaml
+++ b/components/Media/samples/CrossFadeEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -43,9 +42,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind CrossFadeAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 </Page>

--- a/components/Media/samples/EffectAnimationsSample.xaml
+++ b/components/Media/samples/EffectAnimationsSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:animations="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -74,9 +73,9 @@
         </animations:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind ClipAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Grid>
 </Page>

--- a/components/Media/samples/ExposureEffectAnimationSample.xaml
+++ b/components/Media/samples/ExposureEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -39,9 +38,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind ExposureAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 </Page>

--- a/components/Media/samples/HueRotationEffectAnimationSample.xaml
+++ b/components/Media/samples/HueRotationEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -39,9 +38,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind HueRotationAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 </Page>

--- a/components/Media/samples/OpacityEffectAnimationSample.xaml
+++ b/components/Media/samples/OpacityEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -35,9 +34,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind OpacityAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 </Page>

--- a/components/Media/samples/SaturationEffectAnimationSample.xaml
+++ b/components/Media/samples/SaturationEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -38,9 +37,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind SaturationAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 </Page>

--- a/components/Media/samples/SepiaEffectAnimationSample.xaml
+++ b/components/Media/samples/SepiaEffectAnimationSample.xaml
@@ -3,7 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ani="using:CommunityToolkit.WinUI.Animations"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:media="using:CommunityToolkit.WinUI.Media">
 
@@ -38,9 +37,9 @@
         </ani:Explicit.Animations>
 
         <interactivity:Interaction.Behaviors>
-            <interactions:EventTriggerBehavior EventName="Loaded">
+            <interactivity:EventTriggerBehavior EventName="Loaded">
                 <behaviors:StartAnimationAction Animation="{x:Bind SepiaAnimation}" />
-            </interactions:EventTriggerBehavior>
+            </interactivity:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
     </Border>
 </Page>

--- a/components/Media/src/Dependencies.props
+++ b/components/Media/src/Dependencies.props
@@ -12,7 +12,7 @@
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
     <PackageReference Include="Win2D.uwp" Version="1.28.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->

--- a/components/Media/src/Effects/Extensions/AcrylicSourceExtension.cs
+++ b/components/Media/src/Effects/Extensions/AcrylicSourceExtension.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.WinUI.Media;
 /// </summary>
 /// <remarks>This effect mirrors the look of the default <see cref="AcrylicBrush"/> implementation</remarks>
 [MarkupExtensionReturnType(ReturnType = typeof(PipelineBuilder))]
-public sealed class AcrylicSourceExtension : MarkupExtension
+public sealed partial class AcrylicSourceExtension : MarkupExtension
 {
     /// <summary>
     /// Gets or sets the background source mode for the effect (the default is <see cref="AcrylicBackgroundSource.Backdrop"/>).

--- a/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
+++ b/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.WinUI.Controls;
-#if WINAPPSDK
+#if WINUI3
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Provider;
 #else
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Provider;
 #endif
 
@@ -47,16 +49,12 @@ public partial class TokenizingTextBoxAutomationPeer : ListViewBaseAutomationPee
 
     /// <summary>Sets the value of a control.</summary>
     /// <param name="value">The value to set. The provider is responsible for converting the value to the appropriate data type.</param>
-    /// <exception cref="T:Windows.UI.Xaml.Automation.ElementNotEnabledException">Thrown if the control is in a read-only state.</exception>
+    /// <exception cref="T:ElementNotEnabledException">Thrown if the control is in a read-only state.</exception>
     public void SetValue(string value)
     {
         if (IsReadOnly)
         {
-#if NET8_0_OR_GREATER
-            throw new Microsoft.UI.Xaml.Automation.ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
-#elif WINDOWS_UWP
-            throw new Windows.UI.Xaml.Automation.ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
-#endif
+            throw new ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
         }
 
         this.OwningTokenizingTextBox.Text = value;

--- a/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
+++ b/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
@@ -54,8 +54,7 @@ public partial class TokenizingTextBoxAutomationPeer : ListViewBaseAutomationPee
         {
             #if WINDOWS_UWP
             #if NET8_0_OR_GREATER
-            // TODO: ElementNotEnabledException not available on modern uwp.
-            throw new Exception($"Could not set the value of the {nameof(TokenizingTextBox)} ");
+            throw new Microsoft.UI.Xaml.Automation.ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
             #else
             throw new Windows.UI.Xaml.Automation.ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
             #endif

--- a/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
+++ b/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
@@ -52,13 +52,11 @@ public partial class TokenizingTextBoxAutomationPeer : ListViewBaseAutomationPee
     {
         if (IsReadOnly)
         {
-            #if WINDOWS_UWP
-            #if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER
             throw new Microsoft.UI.Xaml.Automation.ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
-            #else
+#elif WINDOWS_UWP
             throw new Windows.UI.Xaml.Automation.ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
-            #endif
-            #endif
+#endif
         }
 
         this.OwningTokenizingTextBox.Text = value;

--- a/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
+++ b/components/TokenizingTextBox/src/TokenizingTextBoxAutomationPeer.cs
@@ -52,7 +52,14 @@ public partial class TokenizingTextBoxAutomationPeer : ListViewBaseAutomationPee
     {
         if (IsReadOnly)
         {
-            throw new ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
+            #if WINDOWS_UWP
+            #if NET8_0_OR_GREATER
+            // TODO: ElementNotEnabledException not available on modern uwp.
+            throw new Exception($"Could not set the value of the {nameof(TokenizingTextBox)} ");
+            #else
+            throw new Windows.UI.Xaml.Automation.ElementNotEnabledException($"Could not set the value of the {nameof(TokenizingTextBox)} ");
+            #endif
+            #endif
         }
 
         this.OwningTokenizingTextBox.Text = value;

--- a/components/TokenizingTextBox/tests/Test_TokenizingTextBox_AutomationPeer.cs
+++ b/components/TokenizingTextBox/tests/Test_TokenizingTextBox_AutomationPeer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Tests;
+using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Automation.Peers;
 using CommunityToolkit.WinUI.Controls;
 
@@ -10,7 +11,7 @@ namespace TokenizingTextBoxExperiment.Tests;
 
 [TestClass]
 [TestCategory("Test_TokenizingTextBox")]
-public class Test_TokenizingTextBox_AutomationPeer : VisualUITestBase
+public partial class Test_TokenizingTextBox_AutomationPeer : VisualUITestBase
 {
     [TestMethod]
     public async Task ShouldConfigureTokenizingTextBoxAutomationPeerAsync()
@@ -83,24 +84,21 @@ public class Test_TokenizingTextBox_AutomationPeer : VisualUITestBase
         });
     }
 
-    [TestMethod]
+    [UIThreadTestMethod]
     public async Task ShouldThrowElementNotEnabledExceptionIfValueSetWhenDisabled()
     {
-        await App.DispatcherQueue.EnqueueAsync(async () =>
+        const string expectedValue = "Wor";
+
+        var tokenizingTextBox = new TokenizingTextBox { IsEnabled = false };
+
+        await LoadTestContentAsync(tokenizingTextBox);
+
+        var tokenizingTextBoxAutomationPeer =
+            FrameworkElementAutomationPeer.CreatePeerForElement(tokenizingTextBox) as TokenizingTextBoxAutomationPeer;
+
+        Assert.ThrowsException<ElementNotEnabledException>(() =>
         {
-            const string expectedValue = "Wor";
-
-            var tokenizingTextBox = new TokenizingTextBox { IsEnabled = false };
-
-            await LoadTestContentAsync(tokenizingTextBox);
-
-            var tokenizingTextBoxAutomationPeer =
-                FrameworkElementAutomationPeer.CreatePeerForElement(tokenizingTextBox) as TokenizingTextBoxAutomationPeer;
-
-            Assert.ThrowsException<ElementNotEnabledException>(() =>
-            {
-                tokenizingTextBoxAutomationPeer!.SetValue(expectedValue);
-            });
+            tokenizingTextBoxAutomationPeer!.SetValue(expectedValue);
         });
     }
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.403",
+    "version": "9.0.101",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,5 @@
 <configuration>
   <packageSources>
-    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,7 @@
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="PullRequests" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-PullRequests/nuget/v3/index.json" protocolVersion="3" />
     <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="PullRequests" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-PullRequests/nuget/v3/index.json" protocolVersion="3" />
     <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
For components that declare a `uwp` MultiTarget, this PR:
- Introduces the `net8.0-windows10.0.26100.0` TFM alongside the existing `uap10.0.17763` 
- Auto-enables the required properties for targeting modern dotnet in uwp
- Updates several platform packages to versions that support modern dotnet on uwp
- Adds several workarounds and fixes to get builds working again with all the latest tooling

Prerequisite PRs:
- https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/235
- https://github.com/CommunityToolkit/Windows/pull/563