### PR TITLE
Bump Win2D dependencies

### DIFF
--- a/components/ImageCropper/src/Dependencies.props
+++ b/components/ImageCropper/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
-        <PackageReference Include="Win2D.uwp" Version="1.28.0"/>
+        <PackageReference Include="Win2D.uwp" Version="1.28.1"/>
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
@@ -21,7 +21,7 @@
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-        <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.0"/>
+        <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->

--- a/components/Media/src/Dependencies.props
+++ b/components/Media/src/Dependencies.props
@@ -1,5 +1,5 @@
 <!--
-    WinUI 2 under UWP uses TargetFramework uap10.0.*
+    WinUI 2 under UWP uses TargetFramework uap10.0.* or net8.0-windows10.*
     WinUI 3 under WinAppSdk uses TargetFramework net6.0-windows10.*
     However, under Uno-powered platforms, both WinUI 2 and 3 can share the same TargetFramework.
     
@@ -11,12 +11,15 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="Win2D.uwp" Version="1.28.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+    <PackageReference Include="Win2D.uwp" Version="1.28.1" />
+
+    <!-- Only include this polyfill package when not targeting .NET 8 or above -->
+    <PackageReference Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))"
+                      Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR just includes two changes:
- Bumps Win2D to latest
- Removes a polyfill package on UWP .NET 8