### PR TITLE
Add Support For Expander In FindChild 

### DIFF
--- a/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
+++ b/components/Extensions/src/Tree/FrameworkElementExtensions.LogicalTree.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using CommunityToolkit.WinUI.Predicates;
+using Microsoft.UI.Xaml.Controls;
 
 #nullable enable
 
@@ -150,6 +151,24 @@ public static partial class FrameworkElementExtensions
         }
         else if (element is ContentControl contentControl)
         {
+            if (element is Expander expander)
+            {
+                if (expander.Header is FrameworkElement header)
+                {
+                    if (header is T result && predicate.Match(result))
+                    {
+                        return result;
+                    }
+
+                    T? descendant = FindChild<T, TPredicate>(header, ref predicate);
+
+                    if (descendant is not null)
+                    {
+                        return descendant;
+                    }
+                }
+            }
+
             if (contentControl.Content is FrameworkElement content)
             {
                 if (content is T result && predicate.Match(result))
@@ -378,6 +397,19 @@ public static partial class FrameworkElementExtensions
         }
         else if (element is ContentControl contentControl)
         {
+            if (element is Expander expander)
+            {
+                if (expander.Header is FrameworkElement header)
+                {
+                    yield return header;
+
+                    foreach (FrameworkElement childOfChild in FindChildren(header))
+                    {
+                        yield return childOfChild;
+                    }
+                }
+            }
+
             if (contentControl.Content is FrameworkElement content)
             {
                 yield return content;


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

Addresses #472

Adds support for searching an Expander control's header. The current logic only searches the content of the Expander control, but not the header.

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

Doesn't find framework elements in the header of an Expander control.

## What is the new behavior?

Finds framework elements in the header of an Expander control.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [ ] Tested code with current supported SDKs
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

No tests. I believe the Logical Tree Tests are not being run (#474).
