### PR TITLE
Fixed issue with IncrementalLoadingCollection within AdvancedCollecti…

### DIFF
--- a/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/components/Collections/src/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -386,16 +386,7 @@ public partial class AdvancedCollectionView : IAdvancedCollectionView, INotifyPr
         if (!_sortProperties.Any())
         {
             var listType = _source?.GetType();
-            Type type;
-
-            if (listType != null && listType.IsGenericType)
-            {
-                type = listType.GetGenericArguments()[0];
-            }
-            else
-            {
-                type = x.GetType();
-            }
+            Type type = x.GetType();
 
             foreach (var sd in _sortDescriptions)
             {


### PR DESCRIPTION
…onView

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #642 

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
Fixed issue #642 by changing how the ACV handles generic types. The change is not perfect, but I wanted to be as non-invasive as possible. Ideally, `AdvancedCollectionView` would be generically typed itself, but that would be a major change.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

Bugfix 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
#642 
The current behavior throws a `NullReferenceException` when `IncrementalLoadingCollection` is used as the source of the ACV. this happens because the first generic type argument of the `IncrementalLoadingColleciton` is not the type of the objects in the list, but rather the type of the `IIncrementalSource` used when constructing the ILC.

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
The new behavior fixes this issue by removing the generic type check and replacing it with the default behavior, which is to use the type of the first object being compared. It's not the most elegant solution, but it's non-invasive.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit(https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
