### PR TITLE
Added CenterHorizontally and CenterVertically to the ListView Extensions | Smooth Scroll Into View

### DIFF
--- a/components/Extensions/src/ListViewBase/ScrollItemPlacement.cs
+++ b/components/Extensions/src/ListViewBase/ScrollItemPlacement.cs
@@ -25,9 +25,19 @@ public enum ScrollItemPlacement
     Top,
 
     /// <summary>
-    /// Aligned center
+    /// Aligned center (both horizontally and vertically)
     /// </summary>
     Center,
+
+    /// <summary>
+    /// Aligned center horizontally
+    /// </summary>
+    CenterHorizontally,
+
+    /// <summary>
+    /// Aligned center vertically
+    /// </summary>
+    CenterVertically,
 
     /// <summary>
     /// Aligned right


### PR DESCRIPTION
Added `CenterHorizontally` and `CenterVertically` for the ListView Extensions,  Smooth Scrolling Into View



## Fixes

Fixes this issue: https://github.com/CommunityToolkit/Windows/issues/647

## PR Type

- Bugfix 


## What is the current behavior?

Smooth Scroll Into View has a `Center` behavior that centers the ListView both horizontally and vertically at the same time.

## What is the new behavior?

The 2 new behaviors allow for only centering horizontally or only centering vertically.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [x] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (if applicable)
- [ ] Header has been added to all new source files
- [x] Contains **NO** breaking changes

## Other information

Talked about this with XAM Llama on Discord
