### PR TITLE
Hook up TokenizingTextBox AutoSuggestBoxStyle 

### DIFF
--- a/components/TokenizingTextBox/src/TokenizingTextBox.xaml
+++ b/components/TokenizingTextBox/src/TokenizingTextBox.xaml
@@ -23,6 +23,7 @@
 
     <Style x:Key="DefaultTokenizingTextBoxStyle"
            TargetType="controls:TokenizingTextBox">
+        <Setter Property="AutoSuggestBoxStyle" Value="{StaticResource SystemAutoSuggestBoxStyle}" />
         <Setter Property="AutoSuggestBoxTextBoxStyle" Value="{StaticResource TokenizingTextBoxTextBoxStyle}" />
         <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
         <Setter Property="Background" Value="{ThemeResource TextControlBackground}" />

--- a/components/TokenizingTextBox/src/TokenizingTextBoxItem.AutoSuggestBox.xaml
+++ b/components/TokenizingTextBox/src/TokenizingTextBoxItem.AutoSuggestBox.xaml
@@ -410,7 +410,7 @@
                                     ItemTemplate="{Binding Path=Owner.SuggestedItemTemplate, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                     ItemsSource="{Binding Path=Owner.SuggestedItemsSource, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                     PlaceholderText="{Binding Path=Owner.PlaceholderText, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                    Style="{StaticResource SystemAutoSuggestBoxStyle}"
+                                    Style="{Binding Path=Owner.AutoSuggestBoxStyle, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                     Text="{Binding Text, Mode=TwoWay}"
                                     TextBoxStyle="{StaticResource TokenizingTextBoxTextBoxStyle}"
                                     TextMemberPath="{Binding Path=Owner.TextMemberPath, RelativeSource={RelativeSource Mode=TemplatedParent}}"


### PR DESCRIPTION
## Fixes #656 

The AutoSuggestBoxStyle dependency property is not hooked up to the AutoSuggestBox's style in TokenizingTextBoxItemTextStyle. Is uses the static resource SystemAutoSuggestBoxStyle.

This fix sets the AutoSuggestBox's style in TokenizingTextBoxItemTextStyle to the AutoSuggestBoxStyle of the TokenizingTextBox and sets the AutoSuggestBoxStyle's default value to that of SystemAutoSuggestBoxStyle.

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

TokenizingTextBox's AutoSuggestBoxStyle is not applied

## What is the new behavior?

TokenizingTextBox's AutoSuggestBoxStyle is applied

## PR Checklist

- [X ] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X ] Based off latest main branch of toolkit
- [ X] Tested code with current supported SDKs
- [ X] Contains **NO** breaking changes

