### PR TITLE
Align RootNamespace across tests to remove "Experiment" suffix

### DIFF
--- a/components/Animations/tests/Animations.Tests.projitems
+++ b/components/Animations/tests/Animations.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>39585FC1-232A-4F67-BFB8-7F6DEE296763</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>AnimationsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Animations.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_AnimationBuilderStart.cs" />

--- a/components/Animations/tests/Animations.Tests.projitems
+++ b/components/Animations/tests/Animations.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>39585FC1-232A-4F67-BFB8-7F6DEE296763</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Animations.Tests</Import_RootNamespace>
+    <Import_RootNamespace>AnimationsTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_AnimationBuilderStart.cs" />

--- a/components/Animations/tests/Test_AnimationBuilderStart.cs
+++ b/components/Animations/tests/Test_AnimationBuilderStart.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Animations;
 using System.Numerics;
 
-namespace AnimationsExperiment.Tests;
+namespace Animations.Tests;
 
 [TestClass]
 [TestCategory(nameof(Test_AnimationBuilderStart))]

--- a/components/Animations/tests/Test_AnimationBuilderStart.cs
+++ b/components/Animations/tests/Test_AnimationBuilderStart.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Animations;
 using System.Numerics;
 
-namespace Animations.Tests;
+namespace AnimationsTests;
 
 [TestClass]
 [TestCategory(nameof(Test_AnimationBuilderStart))]

--- a/components/Animations/tests/Test_ExpressionFunctions.cs
+++ b/components/Animations/tests/Test_ExpressionFunctions.cs
@@ -15,7 +15,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Animations.Expressions;
 
-namespace AnimationsExperiment.Tests;
+namespace Animations.Tests;
 
 [TestClass]
 [TestCategory(nameof(Test_ExpressionFunctions))]

--- a/components/Animations/tests/Test_ExpressionFunctions.cs
+++ b/components/Animations/tests/Test_ExpressionFunctions.cs
@@ -15,7 +15,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Animations.Expressions;
 
-namespace Animations.Tests;
+namespace AnimationsTests;
 
 [TestClass]
 [TestCategory(nameof(Test_ExpressionFunctions))]

--- a/components/Behaviors/tests/Behaviors.Tests.projitems
+++ b/components/Behaviors/tests/Behaviors.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>C5924901-9000-4A6D-936D-BD69944E8C8F</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>BehaviorsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Behaviors.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)StackedNotificationsBehaviorsTestPage.xaml.cs">

--- a/components/Behaviors/tests/Behaviors.Tests.projitems
+++ b/components/Behaviors/tests/Behaviors.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>C5924901-9000-4A6D-936D-BD69944E8C8F</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Behaviors.Tests</Import_RootNamespace>
+    <Import_RootNamespace>BehaviorsTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)StackedNotificationsBehaviorsTestPage.xaml.cs">

--- a/components/Behaviors/tests/StackedNotificationsBehaviorTestClass.cs
+++ b/components/Behaviors/tests/StackedNotificationsBehaviorTestClass.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Behaviors.Tests;
+using BehaviorsTests;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Behaviors;
 using Microsoft.Xaml.Interactivity;
 
-namespace StackedNotificationsBehavior.Tests;
+namespace StackedNotificationsBehaviorTests;
 
 [TestClass]
 public partial class StackedNotificationsBehaviorTestClass : VisualUITestBase

--- a/components/Behaviors/tests/StackedNotificationsBehaviorTestClass.cs
+++ b/components/Behaviors/tests/StackedNotificationsBehaviorTestClass.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using BehaviorsExperiment.Tests;
+using Behaviors.Tests;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Behaviors;
 using Microsoft.Xaml.Interactivity;
 
-namespace StackedNotificationsBehaviorExperiment.Tests;
+namespace StackedNotificationsBehavior.Tests;
 
 [TestClass]
 public partial class StackedNotificationsBehaviorTestClass : VisualUITestBase

--- a/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml
+++ b/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="BehaviorsExperiment.Tests.StackedNotificationsBehaviorsTestPage"
+<Page x:Class="Behaviors.Tests.StackedNotificationsBehaviorsTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"

--- a/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml
+++ b/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="Behaviors.Tests.StackedNotificationsBehaviorsTestPage"
+<Page x:Class="BehaviorsTests.StackedNotificationsBehaviorsTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"

--- a/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml.cs
+++ b/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace BehaviorsExperiment.Tests;
+namespace Behaviors.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml.cs
+++ b/components/Behaviors/tests/StackedNotificationsBehaviorsTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Behaviors.Tests;
+namespace BehaviorsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/CameraPreview/tests/CameraPreview.Tests.projitems
+++ b/components/CameraPreview/tests/CameraPreview.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>E4B3B38E-CB22-4C76-8906-018E2191DA41</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>CameraPreviewExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>CameraPreview.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/CameraPreview/tests/CameraPreview.Tests.projitems
+++ b/components/CameraPreview/tests/CameraPreview.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>E4B3B38E-CB22-4C76-8906-018E2191DA41</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>CameraPreview.Tests</Import_RootNamespace>
+    <Import_RootNamespace>CameraPreviewTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/Collections/tests/Collections.Tests.projitems
+++ b/components/Collections/tests/Collections.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>B5DDFE59-3189-4B41-BE43-C90F53367C94</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>CollectionsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Collections.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_AdvancedCollectionView.cs" />

--- a/components/Collections/tests/Collections.Tests.projitems
+++ b/components/Collections/tests/Collections.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>B5DDFE59-3189-4B41-BE43-C90F53367C94</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Collections.Tests</Import_RootNamespace>
+    <Import_RootNamespace>CollectionsTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_AdvancedCollectionView.cs" />

--- a/components/Collections/tests/DataSource.cs
+++ b/components/Collections/tests/DataSource.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Collections.Tests;
+namespace CollectionsTests;
 
 using CommunityToolkit.WinUI.Collections;
 public class DataSource<T> : IIncrementalSource<T>

--- a/components/Collections/tests/DataSource.cs
+++ b/components/Collections/tests/DataSource.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CollectionsExperiment.Tests;
+namespace Collections.Tests;
 
 using CommunityToolkit.WinUI.Collections;
 public class DataSource<T> : IIncrementalSource<T>

--- a/components/Collections/tests/Test_AdvancedCollectionView.cs
+++ b/components/Collections/tests/Test_AdvancedCollectionView.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.WinUI.Collections;
 
 using System.Runtime.CompilerServices;
 
-namespace CollectionsExperiment.Tests;
+namespace Collections.Tests;
 
 [TestClass]
 public class Test_AdvancedCollectionView

--- a/components/Collections/tests/Test_AdvancedCollectionView.cs
+++ b/components/Collections/tests/Test_AdvancedCollectionView.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.WinUI.Collections;
 
 using System.Runtime.CompilerServices;
 
-namespace Collections.Tests;
+namespace CollectionsTests;
 
 [TestClass]
 public class Test_AdvancedCollectionView

--- a/components/Collections/tests/Test_IncrementalLoadingCollection.cs
+++ b/components/Collections/tests/Test_IncrementalLoadingCollection.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Collections;
 
-namespace Collections.Tests;
+namespace CollectionsTests;
 
 [TestClass]
 public class Test_IncrementalLoadingCollection

--- a/components/Collections/tests/Test_IncrementalLoadingCollection.cs
+++ b/components/Collections/tests/Test_IncrementalLoadingCollection.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Collections;
 
-namespace CollectionsExperiment.Tests;
+namespace Collections.Tests;
 
 [TestClass]
 public class Test_IncrementalLoadingCollection

--- a/components/ColorPicker/tests/ColorPicker.Tests.projitems
+++ b/components/ColorPicker/tests/ColorPicker.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>7241E39A-E282-42BF-A260-30BF986D876D</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ColorPicker.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ColorPickerTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleColorPickerTestClass.cs" />

--- a/components/ColorPicker/tests/ColorPicker.Tests.projitems
+++ b/components/ColorPicker/tests/ColorPicker.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>7241E39A-E282-42BF-A260-30BF986D876D</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ColorPickerExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ColorPicker.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleColorPickerTestClass.cs" />

--- a/components/ColorPicker/tests/ExampleColorPickerTestClass.cs
+++ b/components/ColorPicker/tests/ExampleColorPickerTestClass.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 using ColorPicker = CommunityToolkit.WinUI.Controls.ColorPicker;
 
-namespace ColorPicker.Tests;
+namespace ColorPickerTests;
 
 [TestClass]
 public partial class ExampleColorPickerTestClass : VisualUITestBase

--- a/components/ColorPicker/tests/ExampleColorPickerTestClass.cs
+++ b/components/ColorPicker/tests/ExampleColorPickerTestClass.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 using ColorPicker = CommunityToolkit.WinUI.Controls.ColorPicker;
 
-namespace ColorPickerExperiment.Tests;
+namespace ColorPicker.Tests;
 
 [TestClass]
 public partial class ExampleColorPickerTestClass : VisualUITestBase

--- a/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml
+++ b/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ColorPickerExperiment.Tests.ExampleColorPickerTestPage"
+<Page x:Class="ColorPicker.Tests.ExampleColorPickerTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml
+++ b/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ColorPicker.Tests.ExampleColorPickerTestPage"
+<Page x:Class="ColorPickerTests.ExampleColorPickerTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml.cs
+++ b/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ColorPickerExperiment.Tests;
+namespace ColorPicker.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml.cs
+++ b/components/ColorPicker/tests/ExampleColorPickerTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ColorPicker.Tests;
+namespace ColorPickerTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Converters/tests/Converters.Tests.projitems
+++ b/components/Converters/tests/Converters.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>A46DF5FE-B90C-452E-BA13-68E795DEB80C</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ConvertersExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Converters.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_BoolToObjectConverter.cs" />

--- a/components/Converters/tests/Converters.Tests.projitems
+++ b/components/Converters/tests/Converters.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>A46DF5FE-B90C-452E-BA13-68E795DEB80C</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Converters.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ConvertersTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_BoolToObjectConverter.cs" />

--- a/components/Converters/tests/Test_BoolToObjectConverter.cs
+++ b/components/Converters/tests/Test_BoolToObjectConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace Converters.Tests;
+namespace ConvertersTests;
 
 [TestClass]
 public class Test_BoolToObjectConverter

--- a/components/Converters/tests/Test_BoolToObjectConverter.cs
+++ b/components/Converters/tests/Test_BoolToObjectConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace ConvertersExperiment.Tests;
+namespace Converters.Tests;
 
 [TestClass]
 public class Test_BoolToObjectConverter

--- a/components/Converters/tests/Test_DoubleToObjectConverter.cs
+++ b/components/Converters/tests/Test_DoubleToObjectConverter.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace Converters.Tests;
+namespace ConvertersTests;
 
 [TestClass]
 public class Test_DoubleToObjectConverter

--- a/components/Converters/tests/Test_DoubleToObjectConverter.cs
+++ b/components/Converters/tests/Test_DoubleToObjectConverter.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace ConvertersExperiment.Tests;
+namespace Converters.Tests;
 
 [TestClass]
 public class Test_DoubleToObjectConverter

--- a/components/Converters/tests/Test_EmptyCollectionToObjectConverter.cs
+++ b/components/Converters/tests/Test_EmptyCollectionToObjectConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace ConvertersExperiment.Tests;
+namespace Converters.Tests;
 
 [TestClass]
 public class Test_EmptyCollectionToObjectConverter

--- a/components/Converters/tests/Test_EmptyCollectionToObjectConverter.cs
+++ b/components/Converters/tests/Test_EmptyCollectionToObjectConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace Converters.Tests;
+namespace ConvertersTests;
 
 [TestClass]
 public class Test_EmptyCollectionToObjectConverter

--- a/components/Converters/tests/Test_EmptyStringToObjectConverter.cs
+++ b/components/Converters/tests/Test_EmptyStringToObjectConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace Converters.Tests;
+namespace ConvertersTests;
 
 [TestClass]
 public class Test_EmptyStringToObjectConverter

--- a/components/Converters/tests/Test_EmptyStringToObjectConverter.cs
+++ b/components/Converters/tests/Test_EmptyStringToObjectConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace ConvertersExperiment.Tests;
+namespace Converters.Tests;
 
 [TestClass]
 public class Test_EmptyStringToObjectConverter

--- a/components/Converters/tests/Test_StringFormatConverter.cs
+++ b/components/Converters/tests/Test_StringFormatConverter.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace Converters.Tests;
+namespace ConvertersTests;
 
 [TestClass]
 public class Test_StringFormatConverter

--- a/components/Converters/tests/Test_StringFormatConverter.cs
+++ b/components/Converters/tests/Test_StringFormatConverter.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace ConvertersExperiment.Tests;
+namespace Converters.Tests;
 
 [TestClass]
 public class Test_StringFormatConverter

--- a/components/Converters/tests/Test_TaskResultConverter.cs
+++ b/components/Converters/tests/Test_TaskResultConverter.cs
@@ -6,7 +6,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace ConvertersExperiment.Tests;
+namespace Converters.Tests;
 
 [TestClass]
 public class Test_TaskResultConverter

--- a/components/Converters/tests/Test_TaskResultConverter.cs
+++ b/components/Converters/tests/Test_TaskResultConverter.cs
@@ -6,7 +6,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace Converters.Tests;
+namespace ConvertersTests;
 
 [TestClass]
 public class Test_TaskResultConverter

--- a/components/Converters/tests/Test_TypeToObjectConverter.cs
+++ b/components/Converters/tests/Test_TypeToObjectConverter.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace ConvertersExperiment.Tests;
+namespace Converters.Tests;
 
 [TestClass]
 public class Test_TypeToObjectConverter

--- a/components/Converters/tests/Test_TypeToObjectConverter.cs
+++ b/components/Converters/tests/Test_TypeToObjectConverter.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Converters;
 
-namespace Converters.Tests;
+namespace ConvertersTests;
 
 [TestClass]
 public class Test_TypeToObjectConverter

--- a/components/DeveloperTools/tests/DeveloperTools.Tests.projitems
+++ b/components/DeveloperTools/tests/DeveloperTools.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>5034CE36-00F1-493C-88F7-93809DA5DDB6</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>DeveloperTools.Tests</Import_RootNamespace>
+    <Import_RootNamespace>DeveloperToolsTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/DeveloperTools/tests/DeveloperTools.Tests.projitems
+++ b/components/DeveloperTools/tests/DeveloperTools.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>5034CE36-00F1-493C-88F7-93809DA5DDB6</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>DeveloperToolsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>DeveloperTools.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/Extensions/tests/AttachedDropShadowTestPage.xaml
+++ b/components/Extensions/tests/AttachedDropShadowTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="Extensions.Tests.AttachedDropShadowTestPage"
+<Page x:Class="ExtensionsTests.AttachedDropShadowTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/Extensions/tests/AttachedDropShadowTestPage.xaml
+++ b/components/Extensions/tests/AttachedDropShadowTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ExtensionsExperiment.Tests.AttachedDropShadowTestPage"
+<Page x:Class="Extensions.Tests.AttachedDropShadowTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/Extensions/tests/AttachedDropShadowTestPage.xaml.cs
+++ b/components/Extensions/tests/AttachedDropShadowTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Extensions.Tests;
+namespace ExtensionsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Extensions/tests/AttachedDropShadowTestPage.xaml.cs
+++ b/components/Extensions/tests/AttachedDropShadowTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsExperiment.Tests;
+namespace Extensions.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Extensions/tests/AttachedDropShadowTests.cs
+++ b/components/Extensions/tests/AttachedDropShadowTests.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI;
 
-namespace Extensions.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public partial class AttachedDropShadowTests : VisualUITestBase

--- a/components/Extensions/tests/AttachedDropShadowTests.cs
+++ b/components/Extensions/tests/AttachedDropShadowTests.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI;
 
-namespace ExtensionsExperiment.Tests;
+namespace Extensions.Tests;
 
 [TestClass]
 public partial class AttachedDropShadowTests : VisualUITestBase

--- a/components/Extensions/tests/BitmapIconExtensionTestPage.xaml
+++ b/components/Extensions/tests/BitmapIconExtensionTestPage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="ExtensionsComponent.Tests.BitmapIconExtensionTestPage"
+<Page x:Class="ExtensionsTests.BitmapIconExtensionTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/Extensions/tests/BitmapIconExtensionTestPage.xaml.cs
+++ b/components/Extensions/tests/BitmapIconExtensionTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Extensions/tests/BitmapIconExtensionTests.cs
+++ b/components/Extensions/tests/BitmapIconExtensionTests.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public partial class BitmapIconExtensionTests : VisualUITestBase

--- a/components/Extensions/tests/DispatcherQueueExtensionTests.cs
+++ b/components/Extensions/tests/DispatcherQueueExtensionTests.cs
@@ -16,7 +16,7 @@ using DispatcherQueue = Windows.System.DispatcherQueue;
 using DispatcherQueuePriority = Windows.System.DispatcherQueuePriority;
 #endif
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public partial class DispatcherQueueExtensionTests : VisualUITestBase

--- a/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
+++ b/components/Extensions/tests/DispatcherQueueTimerExtensionTests.cs
@@ -16,7 +16,7 @@ using DispatcherQueuePriority = Windows.System.DispatcherQueuePriority;
 using DispatcherQueueTimer = Windows.System.DispatcherQueueTimer;
 #endif
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public partial class DispatcherQueueTimerExtensionTests : VisualUITestBase

--- a/components/Extensions/tests/Element/FrameworkElementExtensionsTests.RelativeAncestor.cs
+++ b/components/Extensions/tests/Element/FrameworkElementExtensionsTests.RelativeAncestor.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public partial class FrameworkElementExtensionsTests : VisualUITestBase

--- a/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml
+++ b/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="ExtensionsComponent.Tests.FrameworkElementRelativeAncestorDataTemplateTestPage"
+<Page x:Class="ExtensionsTests.FrameworkElementRelativeAncestorDataTemplateTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml.cs
+++ b/components/Extensions/tests/Element/FrameworkElementRelativeAncestorDataTemplateTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Extensions/tests/Extensions.Tests.projitems
+++ b/components/Extensions/tests/Extensions.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>E666FD74-48E1-4BA7-A98E-95A90369B598</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Extensions.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ExtensionsTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)BitmapIconExtensionTestPage.xaml.cs">

--- a/components/Extensions/tests/Extensions.Tests.projitems
+++ b/components/Extensions/tests/Extensions.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>E666FD74-48E1-4BA7-A98E-95A90369B598</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ExtensionsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Extensions.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)BitmapIconExtensionTestPage.xaml.cs">

--- a/components/Extensions/tests/Helpers/ObjectWithNullableBoolProperty.cs
+++ b/components/Extensions/tests/Helpers/ObjectWithNullableBoolProperty.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsComponent.Tests.Helpers;
+namespace ExtensionsTests.Helpers;
 
 internal class ObjectWithNullableBoolProperty : DependencyObject
 {

--- a/components/Extensions/tests/Test_EnumValuesExtension.cs
+++ b/components/Extensions/tests/Test_EnumValuesExtension.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_EnumValuesExtension

--- a/components/Extensions/tests/Test_FontIconExtensionMarkupExtension.cs
+++ b/components/Extensions/tests/Test_FontIconExtensionMarkupExtension.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_FontIconExtensionMarkupExtension

--- a/components/Extensions/tests/Test_FontIconSourceExtensionMarkupExtension.cs
+++ b/components/Extensions/tests/Test_FontIconSourceExtensionMarkupExtension.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_FontIconSourceExtensionMarkupExtension

--- a/components/Extensions/tests/Test_LogicalTreeExtensions.cs
+++ b/components/Extensions/tests/Test_LogicalTreeExtensions.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.Tests;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_LogicalTreeExtensions : VisualUITestBase

--- a/components/Extensions/tests/Test_NullableBoolMarkupExtension.cs
+++ b/components/Extensions/tests/Test_NullableBoolMarkupExtension.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ExtensionsComponent.Tests.Helpers;
+using ExtensionsTests.Helpers;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_NullableBoolMarkupExtension

--- a/components/Extensions/tests/Test_PointExtensions.cs
+++ b/components/Extensions/tests/Test_PointExtensions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_PointExtensions

--- a/components/Extensions/tests/Test_RectExtensions.cs
+++ b/components/Extensions/tests/Test_RectExtensions.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_RectExtensions

--- a/components/Extensions/tests/Test_SizeExtensions.cs
+++ b/components/Extensions/tests/Test_SizeExtensions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_SizeExtensions

--- a/components/Extensions/tests/Test_StringExtensions.cs
+++ b/components/Extensions/tests/Test_StringExtensions.cs
@@ -5,7 +5,7 @@
 using System.Numerics;
 using System.Globalization;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_StringExtensions

--- a/components/Extensions/tests/Test_UIElementExtensions_Coordinates.cs
+++ b/components/Extensions/tests/Test_UIElementExtensions_Coordinates.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.Tests;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_UIElementExtensions_Coordinates : VisualUITestBase

--- a/components/Extensions/tests/Test_VisualExtensions.cs
+++ b/components/Extensions/tests/Test_VisualExtensions.cs
@@ -5,7 +5,7 @@
 using System.Numerics;
 using CommunityToolkit.Tests;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 [TestCategory("Test_VisualExtensions")]

--- a/components/Extensions/tests/Test_VisualTreeExtensions.cs
+++ b/components/Extensions/tests/Test_VisualTreeExtensions.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.Tests;
 
-namespace ExtensionsComponent.Tests;
+namespace ExtensionsTests;
 
 [TestClass]
 public class Test_VisualTreeExtensions : VisualUITestBase

--- a/components/HeaderedControls/tests/HeaderedContentControlTestClass.cs
+++ b/components/HeaderedControls/tests/HeaderedContentControlTestClass.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace HeaderedControls.Tests;
+namespace HeaderedControlsTests;
 
 [TestClass]
 public partial class HeaderedContentControlTestClass : VisualUITestBase

--- a/components/HeaderedControls/tests/HeaderedContentControlTestPage.xaml
+++ b/components/HeaderedControls/tests/HeaderedContentControlTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="HeaderedControls.Tests.HeaderedContentControlTestPage"
+<Page x:Class="HeaderedControlsTests.HeaderedContentControlTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/HeaderedControls/tests/HeaderedContentControlTestPage.xaml.cs
+++ b/components/HeaderedControls/tests/HeaderedContentControlTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace HeaderedControls.Tests;
+namespace HeaderedControlsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/HeaderedControls/tests/HeaderedControls.Tests.projitems
+++ b/components/HeaderedControls/tests/HeaderedControls.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>26383DFF-4962-4C54-B444-B170B62D7252</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>HeaderedControlsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>HeaderedControls.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)HeaderedContentControlTestClass.cs" />

--- a/components/HeaderedControls/tests/HeaderedControls.Tests.projitems
+++ b/components/HeaderedControls/tests/HeaderedControls.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>26383DFF-4962-4C54-B444-B170B62D7252</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>HeaderedControls.Tests</Import_RootNamespace>
+    <Import_RootNamespace>HeaderedControlsTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)HeaderedContentControlTestClass.cs" />

--- a/components/HeaderedControls/tests/HeaderedItemsControlTestClass.cs
+++ b/components/HeaderedControls/tests/HeaderedItemsControlTestClass.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace HeaderedControls.Tests;
+namespace HeaderedControlsTests;
 
 [TestClass]
 public partial class HeaderedItemsControlTestClass : VisualUITestBase

--- a/components/HeaderedControls/tests/HeaderedItemsControlTestPage.xaml
+++ b/components/HeaderedControls/tests/HeaderedItemsControlTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="HeaderedControls.Tests.HeaderedItemsControlTestPage"
+<Page x:Class="HeaderedControlsTests.HeaderedItemsControlTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/HeaderedControls/tests/HeaderedItemsControlTestPage.xaml.cs
+++ b/components/HeaderedControls/tests/HeaderedItemsControlTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace HeaderedControls.Tests;
+namespace HeaderedControlsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/HeaderedControls/tests/HeaderedTreeViewTestClass.cs
+++ b/components/HeaderedControls/tests/HeaderedTreeViewTestClass.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace HeaderedControls.Tests;
+namespace HeaderedControlsTests;
 
 [TestClass]
 public partial class HeaderedTreeViewTestClass : VisualUITestBase

--- a/components/HeaderedControls/tests/HeaderedTreeViewTestPage.xaml
+++ b/components/HeaderedControls/tests/HeaderedTreeViewTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="HeaderedControls.Tests.HeaderedTreeViewTestPage"
+<Page x:Class="HeaderedControlsTests.HeaderedTreeViewTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/HeaderedControls/tests/HeaderedTreeViewTestPage.xaml.cs
+++ b/components/HeaderedControls/tests/HeaderedTreeViewTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace HeaderedControls.Tests;
+namespace HeaderedControlsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Helpers/tests/Helpers.Tests.projitems
+++ b/components/Helpers/tests/Helpers.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>6B338BE1-F3DA-44DF-B4F3-D5133C007A05</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>HelpersExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Helpers.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_ColorHelper.cs" />

--- a/components/Helpers/tests/Helpers.Tests.projitems
+++ b/components/Helpers/tests/Helpers.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>6B338BE1-F3DA-44DF-B4F3-D5133C007A05</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Helpers.Tests</Import_RootNamespace>
+    <Import_RootNamespace>HelpersTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_ColorHelper.cs" />

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace Helpers.Tests;
+namespace HelpersTests;
 
 [TestClass]
 public class Test_ColorHelper

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace HelpersExperiment.Tests;
+namespace Helpers.Tests;
 
 [TestClass]
 public class Test_ColorHelper

--- a/components/Helpers/tests/Test_ConnectionHelper.cs
+++ b/components/Helpers/tests/Test_ConnectionHelper.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace HelpersExperiment.Tests;
+namespace Helpers.Tests;
 
 //// TODO: Need Mock to WinRT Issue #3196 - https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/3196
 [TestClass]

--- a/components/Helpers/tests/Test_ConnectionHelper.cs
+++ b/components/Helpers/tests/Test_ConnectionHelper.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace Helpers.Tests;
+namespace HelpersTests;
 
 //// TODO: Need Mock to WinRT Issue #3196 - https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/3196
 [TestClass]

--- a/components/Helpers/tests/Test_ScreenUnitHelper.cs
+++ b/components/Helpers/tests/Test_ScreenUnitHelper.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace Helpers.Tests;
+namespace HelpersTests;
 
 [TestClass]
 public class Test_ScreenUnitHelper

--- a/components/Helpers/tests/Test_ScreenUnitHelper.cs
+++ b/components/Helpers/tests/Test_ScreenUnitHelper.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace HelpersExperiment.Tests;
+namespace Helpers.Tests;
 
 [TestClass]
 public class Test_ScreenUnitHelper

--- a/components/Helpers/tests/Test_WeakEventListener.cs
+++ b/components/Helpers/tests/Test_WeakEventListener.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace HelpersExperiment.Tests;
+namespace Helpers.Tests;
 
 [TestClass]
 public class Test_WeakEventListener

--- a/components/Helpers/tests/Test_WeakEventListener.cs
+++ b/components/Helpers/tests/Test_WeakEventListener.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 
-namespace Helpers.Tests;
+namespace HelpersTests;
 
 [TestClass]
 public class Test_WeakEventListener

--- a/components/ImageCropper/tests/ImageCropper.Tests.projitems
+++ b/components/ImageCropper/tests/ImageCropper.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>ED5ED007-DAC5-4018-898F-DE03DAA67173</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ImageCropper.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ImageCropperTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/ImageCropper/tests/ImageCropper.Tests.projitems
+++ b/components/ImageCropper/tests/ImageCropper.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>ED5ED007-DAC5-4018-898F-DE03DAA67173</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ImageCropperExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ImageCropper.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/LayoutTransformControl/tests/LayoutTransformControl.Tests.projitems
+++ b/components/LayoutTransformControl/tests/LayoutTransformControl.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>3F30E029-8FAC-4F2C-852D-5298DC74FC3D</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>LayoutTransformControlExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>LayoutTransformControl.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/LayoutTransformControl/tests/LayoutTransformControl.Tests.projitems
+++ b/components/LayoutTransformControl/tests/LayoutTransformControl.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>3F30E029-8FAC-4F2C-852D-5298DC74FC3D</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>LayoutTransformControl.Tests</Import_RootNamespace>
+    <Import_RootNamespace>LayoutTransformControlTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/Media/tests/Media.Tests.projitems
+++ b/components/Media/tests/Media.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>29B0EAEF-DDC3-461E-BE63-4052976510E8</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Media.Tests</Import_RootNamespace>
+    <Import_RootNamespace>MediaTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/Media/tests/Media.Tests.projitems
+++ b/components/Media/tests/Media.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>29B0EAEF-DDC3-461E-BE63-4052976510E8</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>MediaExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Media.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/MetadataControl/tests/MetadataControl.Tests.projitems
+++ b/components/MetadataControl/tests/MetadataControl.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>44685B7D-B5D2-401F-8EFA-843568DCCF8D</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>MetadataControl.Tests</Import_RootNamespace>
+    <Import_RootNamespace>MetadataControlTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/MetadataControl/tests/MetadataControl.Tests.projitems
+++ b/components/MetadataControl/tests/MetadataControl.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>44685B7D-B5D2-401F-8EFA-843568DCCF8D</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>MetadataControlExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>MetadataControl.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/Primitives/tests/Primitives.Tests.projitems
+++ b/components/Primitives/tests/Primitives.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>FCB7491B-6DFB-419F-8482-315C6F59C5AC</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Primitives.Tests</Import_RootNamespace>
+    <Import_RootNamespace>PrimitivesTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchConverterBrushSample.xaml.cs">

--- a/components/Primitives/tests/Primitives.Tests.projitems
+++ b/components/Primitives/tests/Primitives.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>FCB7491B-6DFB-419F-8482-315C6F59C5AC</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>PrimitivesExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Primitives.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)SwitchPresenter\SwitchConverterBrushSample.xaml.cs">

--- a/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml
+++ b/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml
@@ -1,10 +1,10 @@
-<Page x:Class="PrimitivesExperiment.Tests.SwitchConverterBrushSample"
+<Page x:Class="Primitives.Tests.SwitchConverterBrushSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"
       xmlns:converters="using:CommunityToolkit.WinUI.Converters"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:local="using:PrimitivesExperiment.Tests"
+      xmlns:local="using:Primitives.Tests"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:ui="using:CommunityToolkit.WinUI"
       mc:Ignorable="d">

--- a/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml
+++ b/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml
@@ -1,10 +1,10 @@
-<Page x:Class="Primitives.Tests.SwitchConverterBrushSample"
+<Page x:Class="PrimitivesTests.SwitchConverterBrushSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"
       xmlns:converters="using:CommunityToolkit.WinUI.Converters"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:local="using:Primitives.Tests"
+      xmlns:local="using:PrimitivesTests"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:ui="using:CommunityToolkit.WinUI"
       mc:Ignorable="d">

--- a/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 public sealed partial class SwitchConverterBrushSample : Page
 {

--- a/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchConverterBrushSample.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 public sealed partial class SwitchConverterBrushSample : Page
 {

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="PrimitivesExperiment.Tests.SwitchPresenterLayoutSample"
+<Page x:Class="Primitives.Tests.SwitchPresenterLayoutSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="Primitives.Tests.SwitchPresenterLayoutSample"
+<Page x:Class="PrimitivesTests.SwitchPresenterLayoutSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 public sealed partial class SwitchPresenterLayoutSample : Page
 {

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterLayoutSample.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 public sealed partial class SwitchPresenterLayoutSample : Page
 {

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.WinUI.Converters;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public partial class SwitchPresenterTests : VisualUITestBase

--- a/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
+++ b/components/Primitives/tests/SwitchPresenter/SwitchPresenterTests.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.WinUI.Converters;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public partial class SwitchPresenterTests : VisualUITestBase

--- a/components/Primitives/tests/Test_ConstrainedBox.Alignment.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Alignment.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 /// <summary>
 /// These tests check whether the inner alignment of the box within it's parent works as expected.

--- a/components/Primitives/tests/Test_ConstrainedBox.Alignment.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Alignment.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 /// <summary>
 /// These tests check whether the inner alignment of the box within it's parent works as expected.

--- a/components/Primitives/tests/Test_ConstrainedBox.AspectRatio.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.AspectRatio.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 using System.Globalization;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public partial class Test_ConstrainedBox : VisualUITestBase

--- a/components/Primitives/tests/Test_ConstrainedBox.AspectRatio.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.AspectRatio.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 using System.Globalization;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public partial class Test_ConstrainedBox : VisualUITestBase

--- a/components/Primitives/tests/Test_ConstrainedBox.Coerce.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Coerce.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 /// <summary>
 /// These tests check for the various values which can be coerced and changed if out of bounds for each property.

--- a/components/Primitives/tests/Test_ConstrainedBox.Coerce.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Coerce.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 /// <summary>
 /// These tests check for the various values which can be coerced and changed if out of bounds for each property.

--- a/components/Primitives/tests/Test_ConstrainedBox.Combined.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Combined.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tests.Internal;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
     /// <summary>
     /// These tests check multiple constraints are applied together in the correct order.

--- a/components/Primitives/tests/Test_ConstrainedBox.Combined.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Combined.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tests.Internal;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
     /// <summary>
     /// These tests check multiple constraints are applied together in the correct order.

--- a/components/Primitives/tests/Test_ConstrainedBox.Constrict.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Constrict.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 /// <summary>
 /// These tests check for cases where we want to constrain the size of the ConstrainedBox with other

--- a/components/Primitives/tests/Test_ConstrainedBox.Constrict.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Constrict.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 /// <summary>
 /// These tests check for cases where we want to constrain the size of the ConstrainedBox with other

--- a/components/Primitives/tests/Test_ConstrainedBox.Infinity.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Infinity.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 /// <summary>
 /// These tests check for cases where one of the bounds provided by the parent panel is infinite.

--- a/components/Primitives/tests/Test_ConstrainedBox.Infinity.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Infinity.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 /// <summary>
 /// These tests check for cases where one of the bounds provided by the parent panel is infinite.

--- a/components/Primitives/tests/Test_ConstrainedBox.Multiple.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Multiple.cs
@@ -6,7 +6,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 public partial class Test_ConstrainedBox : VisualUITestBase
 {

--- a/components/Primitives/tests/Test_ConstrainedBox.Multiple.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Multiple.cs
@@ -6,7 +6,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 public partial class Test_ConstrainedBox : VisualUITestBase
 {

--- a/components/Primitives/tests/Test_ConstrainedBox.Scale.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Scale.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 public partial class Test_ConstrainedBox : VisualUITestBase
 {

--- a/components/Primitives/tests/Test_ConstrainedBox.Scale.cs
+++ b/components/Primitives/tests/Test_ConstrainedBox.Scale.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 public partial class Test_ConstrainedBox : VisualUITestBase
 {

--- a/components/Primitives/tests/Test_UniformGrid_AutoLayout.cs
+++ b/components/Primitives/tests/Test_UniformGrid_AutoLayout.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public partial class Test_UniformGrid_AutoLayout : VisualUITestBase

--- a/components/Primitives/tests/Test_UniformGrid_AutoLayout.cs
+++ b/components/Primitives/tests/Test_UniformGrid_AutoLayout.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public partial class Test_UniformGrid_AutoLayout : VisualUITestBase

--- a/components/Primitives/tests/Test_UniformGrid_Dimensions.cs
+++ b/components/Primitives/tests/Test_UniformGrid_Dimensions.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public class Test_UniformGrid_Dimensions

--- a/components/Primitives/tests/Test_UniformGrid_Dimensions.cs
+++ b/components/Primitives/tests/Test_UniformGrid_Dimensions.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public class Test_UniformGrid_Dimensions

--- a/components/Primitives/tests/Test_UniformGrid_FreeSpots.cs
+++ b/components/Primitives/tests/Test_UniformGrid_FreeSpots.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Common;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public class Test_UniformGrid_FreeSpots

--- a/components/Primitives/tests/Test_UniformGrid_FreeSpots.cs
+++ b/components/Primitives/tests/Test_UniformGrid_FreeSpots.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Common;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public class Test_UniformGrid_FreeSpots

--- a/components/Primitives/tests/Test_UniformGrid_RowColDefinitions.cs
+++ b/components/Primitives/tests/Test_UniformGrid_RowColDefinitions.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public class Test_UniformGrid_RowColDefinitions

--- a/components/Primitives/tests/Test_UniformGrid_RowColDefinitions.cs
+++ b/components/Primitives/tests/Test_UniformGrid_RowColDefinitions.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public class Test_UniformGrid_RowColDefinitions

--- a/components/Primitives/tests/Test_WrapPanel_BasicLayout.cs
+++ b/components/Primitives/tests/Test_WrapPanel_BasicLayout.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public class Test_WrapPanel_BasicLayout : VisualUITestBase

--- a/components/Primitives/tests/Test_WrapPanel_BasicLayout.cs
+++ b/components/Primitives/tests/Test_WrapPanel_BasicLayout.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public class Test_WrapPanel_BasicLayout : VisualUITestBase

--- a/components/Primitives/tests/Test_WrapPanel_Visibility.cs
+++ b/components/Primitives/tests/Test_WrapPanel_Visibility.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 [TestClass]
 public class Test_WrapPanel_Visibility : VisualUITestBase

--- a/components/Primitives/tests/Test_WrapPanel_Visibility.cs
+++ b/components/Primitives/tests/Test_WrapPanel_Visibility.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 [TestClass]
 public class Test_WrapPanel_Visibility : VisualUITestBase

--- a/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml
+++ b/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="Primitives.Tests.AutoLayoutFixedElementZeroZeroSpecialPage"
+<Page x:Class="PrimitivesTests.AutoLayoutFixedElementZeroZeroSpecialPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml
+++ b/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="PrimitivesExperiment.Tests.AutoLayoutFixedElementZeroZeroSpecialPage"
+<Page x:Class="Primitives.Tests.AutoLayoutFixedElementZeroZeroSpecialPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml.cs
+++ b/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Primitives.Tests;
+namespace PrimitivesTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml.cs
+++ b/components/Primitives/tests/UniformGrid/AutoLayoutFixedElementZeroZeroSpecialPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace PrimitivesExperiment.Tests;
+namespace Primitives.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/RadialGauge/tests/RadialGauge.Tests.projitems
+++ b/components/RadialGauge/tests/RadialGauge.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>2D8A9068-EF5F-4569-982C-D7147398B174</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RadialGaugeExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RadialGauge.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_RadialGauge.cs" />

--- a/components/RadialGauge/tests/RadialGauge.Tests.projitems
+++ b/components/RadialGauge/tests/RadialGauge.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>2D8A9068-EF5F-4569-982C-D7147398B174</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RadialGauge.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RadialGaugeTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_RadialGauge.cs" />

--- a/components/RadialGauge/tests/Test_RadialGauge.cs
+++ b/components/RadialGauge/tests/Test_RadialGauge.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace RadialGaugeExperiment.Tests;
+namespace RadialGauge.Tests;
 
 [TestClass]
 public class Test_RadialGauge

--- a/components/RadialGauge/tests/Test_RadialGauge.cs
+++ b/components/RadialGauge/tests/Test_RadialGauge.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace RadialGauge.Tests;
+namespace RadialGaugeTests;
 
 [TestClass]
 public class Test_RadialGauge

--- a/components/RangeSelector/tests/RangeSelector.Tests.projitems
+++ b/components/RangeSelector/tests/RangeSelector.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>B6882184-C4B7-4A9B-BDB5-2D013E45DC70</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RangeSelector.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RangeSelectorTests</Import_RootNamespace>
   </PropertyGroup>
 <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)RangeSelectorTest.cs" />

--- a/components/RangeSelector/tests/RangeSelector.Tests.projitems
+++ b/components/RangeSelector/tests/RangeSelector.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>B6882184-C4B7-4A9B-BDB5-2D013E45DC70</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RangeSelectorExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RangeSelector.Tests</Import_RootNamespace>
   </PropertyGroup>
 <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)RangeSelectorTest.cs" />

--- a/components/RangeSelector/tests/RangeSelectorTest.cs
+++ b/components/RangeSelector/tests/RangeSelectorTest.cs
@@ -15,7 +15,7 @@
 //using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 //using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 
-//namespace RangeSelector.Tests
+//namespace RangeSelectorTests
 //{
 //    [TestClass]
 //    public class RangeSelectorTest : UITestBase

--- a/components/RangeSelector/tests/RangeSelectorTest.cs
+++ b/components/RangeSelector/tests/RangeSelectorTest.cs
@@ -15,7 +15,7 @@
 //using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 //using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 
-//namespace RangeSelectorExperiment.Tests
+//namespace RangeSelector.Tests
 //{
 //    [TestClass]
 //    public class RangeSelectorTest : UITestBase

--- a/components/RangeSelector/tests/RangeSelectorTestPage.xaml
+++ b/components/RangeSelector/tests/RangeSelectorTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="RangeSelector.Tests.RangeSelectorTestPage"
+<Page x:Class="RangeSelectorTests.RangeSelectorTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/RangeSelector/tests/RangeSelectorTestPage.xaml
+++ b/components/RangeSelector/tests/RangeSelectorTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="RangeSelectorExperiment.Tests.RangeSelectorTestPage"
+<Page x:Class="RangeSelector.Tests.RangeSelectorTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/RangeSelector/tests/RangeSelectorTestPage.xaml.cs
+++ b/components/RangeSelector/tests/RangeSelectorTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace RangeSelectorExperiment.Tests;
+namespace RangeSelector.Tests;
 
 public sealed partial class RangeSelectorTestPage : Page
 {

--- a/components/RangeSelector/tests/RangeSelectorTestPage.xaml.cs
+++ b/components/RangeSelector/tests/RangeSelectorTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace RangeSelector.Tests;
+namespace RangeSelectorTests;
 
 public sealed partial class RangeSelectorTestPage : Page
 {

--- a/components/RangeSelector/tests/Test_RangeSelector.cs
+++ b/components/RangeSelector/tests/Test_RangeSelector.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace RangeSelectorExperiment.Tests;
+namespace RangeSelector.Tests;
 
 [TestClass]
 public class Test_RangeSelector : VisualUITestBase

--- a/components/RangeSelector/tests/Test_RangeSelector.cs
+++ b/components/RangeSelector/tests/Test_RangeSelector.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace RangeSelector.Tests;
+namespace RangeSelectorTests;
 
 [TestClass]
 public class Test_RangeSelector : VisualUITestBase

--- a/components/RichSuggestBox/tests/RichSuggestBox.Tests.projitems
+++ b/components/RichSuggestBox/tests/RichSuggestBox.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>0D173C44-6D69-49B6-B52D-A71C7141EC73</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RichSuggestBox.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RichSuggestBoxTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)RichSuggestBoxTest.cs" />

--- a/components/RichSuggestBox/tests/RichSuggestBox.Tests.projitems
+++ b/components/RichSuggestBox/tests/RichSuggestBox.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>0D173C44-6D69-49B6-B52D-A71C7141EC73</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RichSuggestBoxExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RichSuggestBox.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)RichSuggestBoxTest.cs" />

--- a/components/RichSuggestBox/tests/RichSuggestBoxTest.cs
+++ b/components/RichSuggestBox/tests/RichSuggestBoxTest.cs
@@ -16,7 +16,7 @@
 //using Microsoft.VisualStudio.TestTools.UnitTesting;
 //#endif
 
-//namespace RichSuggestBoxExperiment.Tests;
+//namespace RichSuggestBox.Tests;
 
 //    [TestClass]
 //    public class RichSuggestBoxTest : UITestBase

--- a/components/RichSuggestBox/tests/RichSuggestBoxTest.cs
+++ b/components/RichSuggestBox/tests/RichSuggestBoxTest.cs
@@ -16,7 +16,7 @@
 //using Microsoft.VisualStudio.TestTools.UnitTesting;
 //#endif
 
-//namespace RichSuggestBox.Tests;
+//namespace RichSuggestBoxTests;
 
 //    [TestClass]
 //    public class RichSuggestBoxTest : UITestBase

--- a/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml
+++ b/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="RichSuggestBox.Tests.RichSuggestBoxTestPage"
+<Page x:Class="RichSuggestBoxTests.RichSuggestBoxTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml
+++ b/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="RichSuggestBoxExperiment.Tests.RichSuggestBoxTestPage"
+<Page x:Class="RichSuggestBox.Tests.RichSuggestBoxTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml.cs
+++ b/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace RichSuggestBoxExperiment.Tests;
+namespace RichSuggestBox.Tests;
 
 public sealed partial class RichSuggestBoxTestPage : Page
 {

--- a/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml.cs
+++ b/components/RichSuggestBox/tests/RichSuggestBoxTestPage.xaml.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.WinUI.Controls;
 
-namespace RichSuggestBox.Tests;
+namespace RichSuggestBoxTests;
 
 public sealed partial class RichSuggestBoxTestPage : Page
 {

--- a/components/RichSuggestBox/tests/Test_RichSuggestBox.cs
+++ b/components/RichSuggestBox/tests/Test_RichSuggestBox.cs
@@ -11,7 +11,7 @@ using Microsoft.UI.Text;
 using Windows.UI.Text;
 #endif
 
-namespace RichSuggestBoxExperiment.Tests;
+namespace RichSuggestBox.Tests;
 
 [TestClass]
 public class Test_RichSuggestBox : VisualUITestBase

--- a/components/RichSuggestBox/tests/Test_RichSuggestBox.cs
+++ b/components/RichSuggestBox/tests/Test_RichSuggestBox.cs
@@ -11,7 +11,7 @@ using Microsoft.UI.Text;
 using Windows.UI.Text;
 #endif
 
-namespace RichSuggestBox.Tests;
+namespace RichSuggestBoxTests;
 
 [TestClass]
 public class Test_RichSuggestBox : VisualUITestBase

--- a/components/Segmented/tests/ExampleSegmentedTestClass.cs
+++ b/components/Segmented/tests/ExampleSegmentedTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace Segmented.Tests;
+namespace SegmentedTests;
 
 [TestClass]
 public partial class ExampleSegmentedTestClass : VisualUITestBase

--- a/components/Segmented/tests/ExampleSegmentedTestClass.cs
+++ b/components/Segmented/tests/ExampleSegmentedTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace SegmentedExperiment.Tests;
+namespace Segmented.Tests;
 
 [TestClass]
 public partial class ExampleSegmentedTestClass : VisualUITestBase

--- a/components/Segmented/tests/ExampleSegmentedTestPage.xaml
+++ b/components/Segmented/tests/ExampleSegmentedTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="SegmentedExperiment.Tests.ExampleSegmentedTestPage"
+<Page x:Class="Segmented.Tests.ExampleSegmentedTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Segmented/tests/ExampleSegmentedTestPage.xaml
+++ b/components/Segmented/tests/ExampleSegmentedTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="Segmented.Tests.ExampleSegmentedTestPage"
+<Page x:Class="SegmentedTests.ExampleSegmentedTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Segmented/tests/ExampleSegmentedTestPage.xaml.cs
+++ b/components/Segmented/tests/ExampleSegmentedTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace SegmentedExperiment.Tests;
+namespace Segmented.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Segmented/tests/ExampleSegmentedTestPage.xaml.cs
+++ b/components/Segmented/tests/ExampleSegmentedTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Segmented.Tests;
+namespace SegmentedTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Segmented/tests/Segmented.Tests.projitems
+++ b/components/Segmented/tests/Segmented.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>AA9FB2D1-9A19-4442-A2FC-B62003F99558</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Segmented.Tests</Import_RootNamespace>
+    <Import_RootNamespace>SegmentedTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleSegmentedTestClass.cs" />

--- a/components/Segmented/tests/Segmented.Tests.projitems
+++ b/components/Segmented/tests/Segmented.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>AA9FB2D1-9A19-4442-A2FC-B62003F99558</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>SegmentedExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Segmented.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleSegmentedTestClass.cs" />

--- a/components/SettingsControls/tests/SettingsCardTestPage.xaml
+++ b/components/SettingsControls/tests/SettingsCardTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="SettingsControls.Tests.SettingsCardTestPage"
+<Page x:Class="SettingsControlsTests.SettingsCardTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/SettingsControls/tests/SettingsCardTestPage.xaml
+++ b/components/SettingsControls/tests/SettingsCardTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="SettingsControlsExperiment.Tests.SettingsCardTestPage"
+<Page x:Class="SettingsControls.Tests.SettingsCardTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/SettingsControls/tests/SettingsCardTestPage.xaml.cs
+++ b/components/SettingsControls/tests/SettingsCardTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace SettingsControlsExperiment.Tests;
+namespace SettingsControls.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/SettingsControls/tests/SettingsCardTestPage.xaml.cs
+++ b/components/SettingsControls/tests/SettingsCardTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace SettingsControls.Tests;
+namespace SettingsControlsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/SettingsControls/tests/SettingsControls.Tests.projitems
+++ b/components/SettingsControls/tests/SettingsControls.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>FC9D577B-E440-47F9-96EA-EDBEA7ED05D1</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>SettingsControls.Tests</Import_RootNamespace>
+    <Import_RootNamespace>SettingsControlsTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_SettingsCard.cs" />

--- a/components/SettingsControls/tests/SettingsControls.Tests.projitems
+++ b/components/SettingsControls/tests/SettingsControls.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>FC9D577B-E440-47F9-96EA-EDBEA7ED05D1</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>SettingsControlsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>SettingsControls.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_SettingsCard.cs" />

--- a/components/SettingsControls/tests/SettingsExpanderTestPage.xaml
+++ b/components/SettingsControls/tests/SettingsExpanderTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="SettingsControls.Tests.SettingsExpanderTestPage"
+<Page x:Class="SettingsControlsTests.SettingsExpanderTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/SettingsControls/tests/SettingsExpanderTestPage.xaml
+++ b/components/SettingsControls/tests/SettingsExpanderTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="SettingsControlsExperiment.Tests.SettingsExpanderTestPage"
+<Page x:Class="SettingsControls.Tests.SettingsExpanderTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/SettingsControls/tests/SettingsExpanderTestPage.xaml.cs
+++ b/components/SettingsControls/tests/SettingsExpanderTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace SettingsControlsExperiment.Tests;
+namespace SettingsControls.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/SettingsControls/tests/SettingsExpanderTestPage.xaml.cs
+++ b/components/SettingsControls/tests/SettingsExpanderTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace SettingsControls.Tests;
+namespace SettingsControlsTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/SettingsControls/tests/Test_SettingsCard.cs
+++ b/components/SettingsControls/tests/Test_SettingsCard.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace SettingsControlsExperiment.Tests;
+namespace SettingsControls.Tests;
 
 [TestClass]
 public partial class SettingsCardTestClass : VisualUITestBase

--- a/components/SettingsControls/tests/Test_SettingsCard.cs
+++ b/components/SettingsControls/tests/Test_SettingsCard.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace SettingsControls.Tests;
+namespace SettingsControlsTests;
 
 [TestClass]
 public partial class SettingsCardTestClass : VisualUITestBase

--- a/components/SettingsControls/tests/Test_SettingsExpander.cs
+++ b/components/SettingsControls/tests/Test_SettingsExpander.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace SettingsControls.Tests;
+namespace SettingsControlsTests;
 
 [TestClass]
 public partial class SettingsExpanderTestClass : VisualUITestBase

--- a/components/SettingsControls/tests/Test_SettingsExpander.cs
+++ b/components/SettingsControls/tests/Test_SettingsExpander.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace SettingsControlsExperiment.Tests;
+namespace SettingsControls.Tests;
 
 [TestClass]
 public partial class SettingsExpanderTestClass : VisualUITestBase

--- a/components/Sizers/tests/ContentSizerTestInitialLayout.xaml
+++ b/components/Sizers/tests/ContentSizerTestInitialLayout.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="SizersExperiment.Tests.ContentSizerTestInitialLayout"
+<Page x:Class="Sizers.Tests.ContentSizerTestInitialLayout"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Sizers/tests/ContentSizerTestInitialLayout.xaml
+++ b/components/Sizers/tests/ContentSizerTestInitialLayout.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="Sizers.Tests.ContentSizerTestInitialLayout"
+<Page x:Class="SizersTests.ContentSizerTestInitialLayout"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Sizers/tests/ContentSizerTestInitialLayout.xaml.cs
+++ b/components/Sizers/tests/ContentSizerTestInitialLayout.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace SizersExperiment.Tests;
+namespace Sizers.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Sizers/tests/ContentSizerTestInitialLayout.xaml.cs
+++ b/components/Sizers/tests/ContentSizerTestInitialLayout.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Sizers.Tests;
+namespace SizersTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Sizers/tests/ExampleSizerBaseTestClass.cs
+++ b/components/Sizers/tests/ExampleSizerBaseTestClass.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls.Automation.Peers;
 
-namespace Sizers.Tests;
+namespace SizersTests;
 
 [TestClass]
 public partial class ExampleSizerBaseTestClass : VisualUITestBase

--- a/components/Sizers/tests/ExampleSizerBaseTestClass.cs
+++ b/components/Sizers/tests/ExampleSizerBaseTestClass.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls.Automation.Peers;
 
-namespace SizersExperiment.Tests;
+namespace Sizers.Tests;
 
 [TestClass]
 public partial class ExampleSizerBaseTestClass : VisualUITestBase

--- a/components/Sizers/tests/PropertySizerTestInitialBinding.xaml
+++ b/components/Sizers/tests/PropertySizerTestInitialBinding.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="Sizers.Tests.PropertySizerTestInitialBinding"
+<Page x:Class="SizersTests.PropertySizerTestInitialBinding"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Sizers/tests/PropertySizerTestInitialBinding.xaml
+++ b/components/Sizers/tests/PropertySizerTestInitialBinding.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="SizersExperiment.Tests.PropertySizerTestInitialBinding"
+<Page x:Class="Sizers.Tests.PropertySizerTestInitialBinding"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Sizers/tests/PropertySizerTestInitialBinding.xaml.cs
+++ b/components/Sizers/tests/PropertySizerTestInitialBinding.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace SizersExperiment.Tests;
+namespace Sizers.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Sizers/tests/PropertySizerTestInitialBinding.xaml.cs
+++ b/components/Sizers/tests/PropertySizerTestInitialBinding.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Sizers.Tests;
+namespace SizersTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Sizers/tests/Sizers.Tests.projitems
+++ b/components/Sizers/tests/Sizers.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>FE1BF6B1-E2B8-4F75-9629-97B5AA077FAA</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>SizersExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Sizers.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ContentSizerTestInitialLayout.xaml.cs">

--- a/components/Sizers/tests/Sizers.Tests.projitems
+++ b/components/Sizers/tests/Sizers.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>FE1BF6B1-E2B8-4F75-9629-97B5AA077FAA</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Sizers.Tests</Import_RootNamespace>
+    <Import_RootNamespace>SizersTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ContentSizerTestInitialLayout.xaml.cs">

--- a/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestClass.cs
+++ b/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TabbedCommandBarExperiment.Tests;
+namespace TabbedCommandBar.Tests;
 
 [TestClass]
 public partial class ExampleTabbedCommandBarTestClass : VisualUITestBase

--- a/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestClass.cs
+++ b/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TabbedCommandBar.Tests;
+namespace TabbedCommandBarTests;
 
 [TestClass]
 public partial class ExampleTabbedCommandBarTestClass : VisualUITestBase

--- a/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml
+++ b/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="TabbedCommandBar.Tests.ExampleTabbedCommandBarTestPage"
+<Page x:Class="TabbedCommandBarTests.ExampleTabbedCommandBarTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml
+++ b/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="TabbedCommandBarExperiment.Tests.ExampleTabbedCommandBarTestPage"
+<Page x:Class="TabbedCommandBar.Tests.ExampleTabbedCommandBarTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml.cs
+++ b/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace TabbedCommandBar.Tests;
+namespace TabbedCommandBarTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml.cs
+++ b/components/TabbedCommandBar/tests/ExampleTabbedCommandBarTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace TabbedCommandBarExperiment.Tests;
+namespace TabbedCommandBar.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/TabbedCommandBar/tests/TabbedCommandBar.Tests.projitems
+++ b/components/TabbedCommandBar/tests/TabbedCommandBar.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>254FF722-89D0-4EEE-8DA3-BE527A57A16E</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TabbedCommandBar.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TabbedCommandBarTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTabbedCommandBarTestClass.cs" />

--- a/components/TabbedCommandBar/tests/TabbedCommandBar.Tests.projitems
+++ b/components/TabbedCommandBar/tests/TabbedCommandBar.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>254FF722-89D0-4EEE-8DA3-BE527A57A16E</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TabbedCommandBarExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TabbedCommandBar.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTabbedCommandBarTestClass.cs" />

--- a/components/TokenizingTextBox/tests/Test_TokenizingTextBox_AutomationPeer.cs
+++ b/components/TokenizingTextBox/tests/Test_TokenizingTextBox_AutomationPeer.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Automation.Peers;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TokenizingTextBoxExperiment.Tests;
+namespace TokenizingTextBox.Tests;
 
 [TestClass]
 [TestCategory("Test_TokenizingTextBox")]

--- a/components/TokenizingTextBox/tests/Test_TokenizingTextBox_AutomationPeer.cs
+++ b/components/TokenizingTextBox/tests/Test_TokenizingTextBox_AutomationPeer.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Automation.Peers;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TokenizingTextBox.Tests;
+namespace TokenizingTextBoxTests;
 
 [TestClass]
 [TestCategory("Test_TokenizingTextBox")]

--- a/components/TokenizingTextBox/tests/Test_TokenizingTextBox_General.cs
+++ b/components/TokenizingTextBox/tests/Test_TokenizingTextBox_General.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TokenizingTextBox.Tests;
+namespace TokenizingTextBoxTests;
 
     [TestClass]
 public class Test_TokenizingTextBox_General : VisualUITestBase

--- a/components/TokenizingTextBox/tests/Test_TokenizingTextBox_General.cs
+++ b/components/TokenizingTextBox/tests/Test_TokenizingTextBox_General.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TokenizingTextBoxExperiment.Tests;
+namespace TokenizingTextBox.Tests;
 
     [TestClass]
 public class Test_TokenizingTextBox_General : VisualUITestBase

--- a/components/TokenizingTextBox/tests/TokenizingTextBox.Tests.projitems
+++ b/components/TokenizingTextBox/tests/TokenizingTextBox.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>0EE1522F-BD8D-4BB1-9B44-303BAE40E457</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TokenizingTextBoxExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TokenizingTextBox.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_TokenizingTextBox_General.cs" />

--- a/components/TokenizingTextBox/tests/TokenizingTextBox.Tests.projitems
+++ b/components/TokenizingTextBox/tests/TokenizingTextBox.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>0EE1522F-BD8D-4BB1-9B44-303BAE40E457</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TokenizingTextBox.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TokenizingTextBoxTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Test_TokenizingTextBox_General.cs" />

--- a/components/Triggers/tests/ControlSizeTriggerTests.cs
+++ b/components/Triggers/tests/ControlSizeTriggerTests.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI;
 
-namespace TriggersExperiment.Tests;
+namespace Triggers.Tests;
 
 [TestClass]
 [TestCategory("ControlSizeTriggerTests")]

--- a/components/Triggers/tests/ControlSizeTriggerTests.cs
+++ b/components/Triggers/tests/ControlSizeTriggerTests.cs
@@ -5,7 +5,7 @@
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI;
 
-namespace Triggers.Tests;
+namespace TriggersTests;
 
 [TestClass]
 [TestCategory("ControlSizeTriggerTests")]

--- a/components/Triggers/tests/Triggers.Tests.projitems
+++ b/components/Triggers/tests/Triggers.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>D7336E4A-3FAF-4E9B-A151-DBDAF210A728</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TriggersExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Triggers.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ControlSizeTriggerTests.cs" />

--- a/components/Triggers/tests/Triggers.Tests.projitems
+++ b/components/Triggers/tests/Triggers.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>D7336E4A-3FAF-4E9B-A151-DBDAF210A728</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Triggers.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TriggersTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ControlSizeTriggerTests.cs" />


### PR DESCRIPTION
Full list of changes can be found in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/272

Requires prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/273