### PR TITLE
Update Uno Behaviors to 3.0.3

### DIFF
--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -16,7 +16,7 @@
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.0-dev.17.g7c09b9114d" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.3" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
@@ -26,6 +26,6 @@
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI" Version="3.0.0-dev.17.g7c09b9114d" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI" Version="3.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR bumps our dependency on `Uno.Microsoft.Xaml.Behaviors.Interactivity` and `Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI` to a stable version, removing our dependency on the prerelease version of 3.x originally added alongside UWP .NET 9 support. 

Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/287