### PR TITLE
Fix workaround in Segmented control

### DIFF
--- a/components/Segmented/src/Segmented/Segmented.cs
+++ b/components/Segmented/src/Segmented/Segmented.cs
@@ -39,6 +39,7 @@ public partial class Segmented : ListViewBase
         base.OnApplyTemplate();
         if (!_hasLoaded)
         {
+            SelectedIndex = -1;
             SelectedIndex = _internalSelectedIndex;
             _hasLoaded = true;
         }


### PR DESCRIPTION
This commit modifies the `OnApplyTemplate` method in the `Segmented` class to set `SelectedIndex` to `-1` and then assign `_internalSelectedIndex` if `_hasLoaded` is false. This ensures the selected index is reset before applying the internal selection and marks the template as loaded.

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes
#698 

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

- Bugfix
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The selected item is not rendered as selected when in XAML:
- 2 `SegmentedItem`s are declared
and
- `SelectedIndex` is set to **1**.
```xaml
<toolkit:Segmented SelectedIndex="1">
    <toolkit:SegmentedItem Content="Item 1" />
    <toolkit:SegmentedItem Content="Item 2" />
</toolkit:Segmented>
```
![image](https://github.com/user-attachments/assets/3a16867a-ea18-485f-98d8-c96df556fd9f)

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
The selected item is rendered as expected.
![image](https://github.com/user-attachments/assets/94d22683-f529-4adc-8eb7-820bf3e0531d)


## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
