### PR TITLE
Fix WrapPanel stretching behavior for last item

### DIFF
--- a/components/Primitives/src/WrapPanel/WrapPanel.cs
+++ b/components/Primitives/src/WrapPanel/WrapPanel.cs
@@ -219,7 +219,8 @@ public partial class WrapPanel : Panel
             }
 
             // Stretch the last item to fill the available space
-            if (isLast)
+            // if the parent measure is not infinite
+            if (isLast && double.IsInfinity(parentMeasure.U) is false)
             {
                 desiredMeasure.U = parentMeasure.U - position.U;
             }


### PR DESCRIPTION
Added a conditional check to prevent the last item in the WrapPanel from stretching when the parent measure's width is infinite.

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->
Fixes #703 and #297

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

- Bugfix
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This code tries to stretch its last item to an infinity width causing *System.Runtime.InteropServices.COMException*.
```xaml
<Grid ColumnDefinitions="Auto">
    <toolkit:WrapPanel StretchChild="Last">
        <Button />
    </toolkit:WrapPanel>
</Grid>
```

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
Doesn't stretch its last item when given an infinity width.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [ ] Header has been added to all new source files
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
