### PR TITLE
Lower the opacity of a BitmapIcon when card is Disabled

### DIFF
--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -228,6 +228,12 @@ public partial class SettingsCard : ButtonBase
     private void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
         VisualStateManager.GoToState(this, IsEnabled ? NormalState : DisabledState, true);
+
+        // The Disabled visual state will only set the right Foreground brush, but for images we need to lower the opacity so it looks disabled.
+        if (HeaderIcon is BitmapIcon && GetTemplateChild(HeaderIconPresenterHolder) is FrameworkElement headerIconPresenter)
+        {
+            headerIconPresenter.Opacity = IsEnabled ? 1 : 0.4;
+        }
     }
 
     private void OnActionIconChanged()


### PR DESCRIPTION
## Fixes

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?
Bugfix 

## What is the current behavior?

<img width="1328" height="343" alt="image" src="https://github.com/user-attachments/assets/d55bf83f-05f6-454c-954d-9a8cc5d20939" />


## What is the new behavior?

<img width="1329" height="333" alt="image" src="https://github.com/user-attachments/assets/f586ae4b-0bc3-45c2-94cd-52a6fa3ac302" />


## PR Checklist

Please check if your PR fulfills the following requirements: 

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [ ] Based off latest main branch of toolkit
- [ ] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [ ] Header has been added to all new source files
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
