### PR TITLE
[ColorHelper] Add new ColorHelper API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
   merge_group:
 
 env:
-  DOTNET_VERSION: '9.0.310'  # Only used by jobs that cannot access global.json (no checkout/artifact-only jobs)
+  DOTNET_VERSION: '10.0.101'  # Only used by jobs that cannot access global.json (no checkout/artifact-only jobs)
   ENABLE_DIAGNOSTICS: true
   MSBUILD_VERBOSITY: normal
   #COREHOST_TRACE: 1

--- a/components/ColorPicker/src/ColorPicker.cs
+++ b/components/ColorPicker/src/ColorPicker.cs
@@ -510,12 +510,12 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
                 if (this.IsAlphaEnabled)
                 {
                     // Remove only the "#" sign
-                    this.HexInputTextBox.Text = rgbColor.ToHex().Replace("#", string.Empty);
+                    this.HexInputTextBox.Text = rgbColor.ToString().TrimStart('#');
                 }
                 else
                 {
                     // Remove the "#" sign and alpha hex
-                    this.HexInputTextBox.Text = rgbColor.ToHex().Replace("#", string.Empty).Substring(2);
+                    this.HexInputTextBox.Text = rgbColor.ToString().TrimStart('#')[2..];
                 }
             }
 
@@ -532,10 +532,10 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
                 int decimals = 0;
                 hsvColor = new HsvColor()
                 {
-                    H = Math.Round(hsvColor.H, decimals),
-                    S = Math.Round(hsvColor.S, 2 + decimals),
-                    V = Math.Round(hsvColor.V, 2 + decimals),
-                    A = Math.Round(hsvColor.A, 2 + decimals)
+                    Hue = Math.Round(hsvColor.Hue, decimals),
+                    Saturation = Math.Round(hsvColor.Saturation, 2 + decimals),
+                    Value = Math.Round(hsvColor.Value, 2 + decimals),
+                    Alpha = Math.Round(hsvColor.Alpha, 2 + decimals)
                 };
 
                 // Must update HSV color
@@ -554,10 +554,10 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
             {
                 this.ColorSpectrumControl.HsvColor = new System.Numerics.Vector4()
                 {
-                    X = Convert.ToSingle(hsvColor.H),
-                    Y = Convert.ToSingle(hsvColor.S),
-                    Z = Convert.ToSingle(hsvColor.V),
-                    W = Convert.ToSingle(hsvColor.A)
+                    X = Convert.ToSingle(hsvColor.Hue),
+                    Y = Convert.ToSingle(hsvColor.Saturation),
+                    Z = Convert.ToSingle(hsvColor.Value),
+                    W = Convert.ToSingle(hsvColor.Alpha)
                 };
             }
 
@@ -565,9 +565,9 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
             if (this.ColorSpectrumThirdDimensionSlider != null)
             {
                 // Convert the channels into a usable range for the user
-                double hue         = hsvColor.H;
-                double staturation = hsvColor.S * 100;
-                double value       = hsvColor.V * 100;
+                double hue         = hsvColor.Hue;
+                double staturation = hsvColor.Saturation * 100;
+                double value       = hsvColor.Value * 100;
 
                 switch (this.GetActiveColorSpectrumThirdDimension())
                 {
@@ -610,10 +610,10 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
             if (this.GetActiveColorRepresentation() == ColorRepresentation.Hsva)
             {
                 // Convert the channels into a usable range for the user
-                double hue         = hsvColor.H;
-                double staturation = hsvColor.S * 100;
-                double value       = hsvColor.V * 100;
-                double alpha       = hsvColor.A * 100;
+                double hue         = hsvColor.Hue;
+                double staturation = hsvColor.Saturation * 100;
+                double value       = hsvColor.Value * 100;
+                double alpha       = hsvColor.Alpha * 100;
 
                 // Hue
                 if (this.Channel1NumberBox != null)
@@ -792,10 +792,10 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
                 oldHsvColor = this.savedHsvColor.Value;
             }
 
-            double hue        = oldHsvColor.H;
-            double saturation = oldHsvColor.S;
-            double value      = oldHsvColor.V;
-            double alpha      = oldHsvColor.A;
+            double hue        = oldHsvColor.Hue;
+            double saturation = oldHsvColor.Saturation;
+            double value      = oldHsvColor.Value;
+            double alpha      = oldHsvColor.Alpha;
 
             switch (channel)
             {
@@ -825,20 +825,11 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
                 }
             }
 
-            newRgbColor = Helpers.ColorHelper.FromHsv(
-                hue,
-                saturation,
-                value,
-                alpha);
+            var hsv = HsvColor.Create(hue, saturation, value, alpha);
+            newRgbColor = hsv;
 
             // Must update HSV color
-            this.savedHsvColor = new HsvColor()
-            {
-                H = hue,
-                S = saturation,
-                V = value,
-                A = alpha
-            };
+            this.savedHsvColor = hsv;
             this.savedHsvColorRgbEquivalent = newRgbColor;
         }
         else
@@ -1351,16 +1342,14 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
     /// </summary>
     private void ColorPreviewer_ColorChangeRequested(object? sender, HsvColor hsvColor)
     {
-        Color rgbColor = Helpers.ColorHelper.FromHsv(hsvColor.H, hsvColor.S, hsvColor.V, hsvColor.A);
-
         // Regardless of the active color model, the previewer always uses HSV
         // Therefore, always calculate HSV color here
         // Warning: Always maintain/use HSV information in the saved HSV color
         // This avoids loss of precision and drift caused by continuously converting to/from RGB
         this.savedHsvColor = hsvColor;
-        this.savedHsvColorRgbEquivalent = rgbColor;
+        this.savedHsvColorRgbEquivalent = hsvColor;
 
-        this.ScheduleColorUpdate(rgbColor);
+        this.ScheduleColorUpdate(hsvColor);
 
         return;
     }

--- a/components/ColorPicker/src/ColorPickerRenderingHelpers.cs
+++ b/components/ColorPicker/src/ColorPickerRenderingHelpers.cs
@@ -79,23 +79,13 @@ internal class ColorPickerRenderingHelpers
             if (isAlphaMaxForced &&
                 channel != ColorChannel.Alpha)
             {
-                baseHsvColor = new HsvColor()
-                {
-                    H = baseHsvColor.H,
-                    S = baseHsvColor.S,
-                    V = baseHsvColor.V,
-                    A = 1.0
-                };
+                baseHsvColor.Alpha = 1.0;
             }
 
             // Convert HSV to RGB once
             if (colorRepresentation == ColorRepresentation.Rgba)
             {
-                baseRgbColor = Helpers.ColorHelper.FromHsv(
-                    baseHsvColor.H,
-                    baseHsvColor.S,
-                    baseHsvColor.V,
-                    baseHsvColor.A);
+                baseRgbColor = baseHsvColor;
             }
 
             // Maximize Saturation and Value channels when in HSVA mode
@@ -106,31 +96,15 @@ internal class ColorPickerRenderingHelpers
                 switch (channel)
                 {
                     case ColorChannel.Channel1:
-                        baseHsvColor = new HsvColor()
-                        {
-                            H = baseHsvColor.H,
-                            S = 1.0,
-                            V = 1.0,
-                            A = baseHsvColor.A
-                        };
+                        baseHsvColor.Saturation = 1.0;
+                        baseHsvColor.Value = 1.0;
                         break;
                     case ColorChannel.Channel2:
-                        baseHsvColor = new HsvColor()
-                        {
-                            H = baseHsvColor.H,
-                            S = baseHsvColor.S,
-                            V = 1.0,
-                            A = baseHsvColor.A
-                        };
+
+                        baseHsvColor.Value = 1;
                         break;
                     case ColorChannel.Channel3:
-                        baseHsvColor = new HsvColor()
-                        {
-                            H = baseHsvColor.H,
-                            S = 1.0,
-                            V = baseHsvColor.V,
-                            A = baseHsvColor.A
-                        };
+                        baseHsvColor.Saturation = 1;
                         break;
                 }
             }
@@ -300,11 +274,9 @@ internal class ColorPickerRenderingHelpers
                         if (colorRepresentation == ColorRepresentation.Hsva)
                         {
                             // Sweep hue
-                            newRgbColor = Helpers.ColorHelper.FromHsv(
-                                Math.Clamp(channelValue, 0.0, 360.0),
-                                baseHsvColor.S,
-                                baseHsvColor.V,
-                                baseHsvColor.A);
+                            var hsv = baseHsvColor;
+                            hsv.Hue = channelValue;
+                            newRgbColor = hsv;
                         }
                         else
                         {
@@ -326,11 +298,9 @@ internal class ColorPickerRenderingHelpers
                         if (colorRepresentation == ColorRepresentation.Hsva)
                         {
                             // Sweep saturation
-                            newRgbColor = Helpers.ColorHelper.FromHsv(
-                                baseHsvColor.H,
-                                Math.Clamp(channelValue, 0.0, 1.0),
-                                baseHsvColor.V,
-                                baseHsvColor.A);
+                            var hsv = baseHsvColor;
+                            hsv.Saturation = channelValue;
+                            newRgbColor = hsv;
                         }
                         else
                         {
@@ -352,11 +322,9 @@ internal class ColorPickerRenderingHelpers
                         if (colorRepresentation == ColorRepresentation.Hsva)
                         {
                             // Sweep value
-                            newRgbColor = Helpers.ColorHelper.FromHsv(
-                                baseHsvColor.H,
-                                baseHsvColor.S,
-                                Math.Clamp(channelValue, 0.0, 1.0),
-                                baseHsvColor.A);
+                            var hsv = baseHsvColor;
+                            hsv.Value = channelValue;
+                            newRgbColor = hsv;
                         }
                         else
                         {
@@ -378,11 +346,9 @@ internal class ColorPickerRenderingHelpers
                         if (colorRepresentation == ColorRepresentation.Hsva)
                         {
                             // Sweep alpha
-                            newRgbColor = Helpers.ColorHelper.FromHsv(
-                                baseHsvColor.H,
-                                baseHsvColor.S,
-                                baseHsvColor.V,
-                                Math.Clamp(channelValue, 0.0, 1.0));
+                            var hsv = baseHsvColor;
+                            hsv.Alpha = channelValue;
+                            newRgbColor = hsv;
                         }
                         else
                         {

--- a/components/ColorPicker/src/ColorPickerSlider.cs
+++ b/components/ColorPicker/src/ColorPickerSlider.cs
@@ -55,7 +55,7 @@ public partial class ColorPickerSlider : Slider
         this.UpdateBackground(hsvColor);
 
         // Calculate and set the foreground ensuring contrast with the background
-        Color rgbColor = Helpers.ColorHelper.FromHsv(hsvColor.H, hsvColor.S, hsvColor.V, hsvColor.A);
+        Color rgbColor = hsvColor;
         Color selectedRgbColor;
         double sliderPercent = this.Value / (this.Maximum - this.Minimum);
 
@@ -64,13 +64,7 @@ public partial class ColorPickerSlider : Slider
             if (this.IsAlphaMaxForced &&
                 this.ColorChannel != ColorChannel.Alpha)
             {
-                hsvColor = new HsvColor()
-                {
-                    H = hsvColor.H,
-                    S = hsvColor.S,
-                    V = hsvColor.V,
-                    A = 1.0
-                };
+                hsvColor.Alpha = 1.0;
             }
 
             switch (this.ColorChannel)
@@ -78,51 +72,39 @@ public partial class ColorPickerSlider : Slider
                 case ColorChannel.Channel1:
                 {
                     var channelValue = Math.Clamp(sliderPercent * 360.0, 0.0, 360.0);
-
-                    hsvColor = new HsvColor()
+                    hsvColor.Hue = channelValue;
+                    if (this.IsSaturationValueMaxForced)
                     {
-                        H = channelValue,
-                        S = this.IsSaturationValueMaxForced ? 1.0 : hsvColor.S,
-                        V = this.IsSaturationValueMaxForced ? 1.0 : hsvColor.V,
-                        A = hsvColor.A
-                    };
+                        hsvColor.Saturation = 1.0;
+                        hsvColor.Value = 1.0;
+                    }
                     break;
                 }
 
                 case ColorChannel.Channel2:
                 {
                     var channelValue = Math.Clamp(sliderPercent * 1.0, 0.0, 1.0);
-
-                    hsvColor = new HsvColor()
+                    hsvColor.Saturation = channelValue;
+                    if (this.IsSaturationValueMaxForced)
                     {
-                        H = hsvColor.H,
-                        S = channelValue,
-                        V = this.IsSaturationValueMaxForced ? 1.0 : hsvColor.V,
-                        A = hsvColor.A
-                    };
+                        hsvColor.Value = 1.0;
+                    }
                     break;
                 }
 
                 case ColorChannel.Channel3:
                 {
                     var channelValue = Math.Clamp(sliderPercent * 1.0, 0.0, 1.0);
-
-                    hsvColor = new HsvColor()
+                    hsvColor.Value = channelValue;
+                    if (this.IsSaturationValueMaxForced)
                     {
-                        H = hsvColor.H,
-                        S = this.IsSaturationValueMaxForced ? 1.0 : hsvColor.S,
-                        V = channelValue,
-                        A = hsvColor.A
-                    };
+                        hsvColor.Saturation = 1.0;
+                    }
                     break;
                 }
             }
 
-            selectedRgbColor = Helpers.ColorHelper.FromHsv(
-                hsvColor.H,
-                hsvColor.S,
-                hsvColor.V,
-                hsvColor.A);
+            selectedRgbColor = hsvColor;
         }
         else
         {

--- a/components/ColorPicker/src/Converters/AccentColorConverter.cs
+++ b/components/ColorPicker/src/Converters/AccentColorConverter.cs
@@ -33,22 +33,13 @@ public partial class AccentColorConverter : IValueConverter
     {
         if (accentStep != 0)
         {
-            double colorValue = hsvColor.V;
+            double colorValue = hsvColor.Value;
             colorValue += accentStep * AccentColorConverter.ValueDelta;
             colorValue = Math.Round(colorValue, 2);
+            hsvColor.Value = colorValue;
+        }
 
-            return new HsvColor()
-            {
-                A = Math.Clamp(hsvColor.A, 0.0, 1.0),
-                H = Math.Clamp(hsvColor.H, 0.0, 360.0),
-                S = Math.Clamp(hsvColor.S, 0.0, 1.0),
-                V = Math.Clamp(colorValue, 0.0, 1.0),
-            };
-        }
-        else
-        {
-            return hsvColor;
-        }
+        return hsvColor;
     }
 
     /// <inheritdoc/>
@@ -63,28 +54,26 @@ public partial class AccentColorConverter : IValueConverter
         HsvColor? hsvColor = null;
 
         // Get the current color in HSV
-        if (value is Color valueColor)
+        switch (value)
         {
-            rgbColor = valueColor;
-        }
-        else if (value is HsvColor valueHsvColor)
-        {
-            hsvColor = valueHsvColor;
-        }
-        else if (value is SolidColorBrush valueBrush)
-        {
-            rgbColor = valueBrush.Color;
-        }
-        else
-        {
-            // Invalid color value provided
-            return DependencyProperty.UnsetValue;
+            case Color valueColor:
+                rgbColor = valueColor;
+                break;
+            case HsvColor valueHsvColor:
+                hsvColor = valueHsvColor;
+                break;
+            case SolidColorBrush valueBrush:
+                rgbColor = valueBrush.Color;
+                break;
+            default:
+                // Invalid color value provided
+                return DependencyProperty.UnsetValue;
         }
 
         // Get the value component delta
         try
         {
-                accentStep = int.Parse(parameter?.ToString()!, CultureInfo.InvariantCulture);
+            accentStep = int.Parse(parameter?.ToString()!, CultureInfo.InvariantCulture);
         }
         catch
         {
@@ -100,9 +89,7 @@ public partial class AccentColorConverter : IValueConverter
 
         if (hsvColor != null)
         {
-            var hsv = AccentColorConverter.GetAccent(hsvColor.Value, accentStep);
-
-            return Helpers.ColorHelper.FromHsv(hsv.H, hsv.S, hsv.V, hsv.A);
+            return (Color)GetAccent(hsvColor.Value, accentStep);
         }
         else
         {

--- a/components/ColorPicker/src/Converters/ColorToHexConverter.cs
+++ b/components/ColorPicker/src/Converters/ColorToHexConverter.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommunityToolkit.WinUI.Helpers;
 using Windows.UI;
+
+using ColorHelper = CommunityToolkit.WinUI.Helpers.ColorHelper;
 
 namespace CommunityToolkit.WinUI.Controls;
 
@@ -21,22 +22,20 @@ public partial class ColorToHexConverter : IValueConverter
     {
         Color color;
 
-        if (value is Color valueColor)
+        switch (value)
         {
-            color = valueColor;
-        }
-        else if (value is SolidColorBrush valueBrush)
-        {
-            color = valueBrush.Color;
-        }
-        else
-        {
-            // Invalid color value provided
-            return DependencyProperty.UnsetValue;
+            case Color valueColor:
+                color = valueColor;
+                break;
+            case SolidColorBrush valueBrush:
+                color = valueBrush.Color;
+                break;
+            default:
+                // Invalid color value provided
+                return DependencyProperty.UnsetValue;
         }
 
-        string hexColor = color.ToHex().Replace("#", string.Empty);
-        return hexColor;
+        return color.ToString().TrimStart('#');
     }
 
     /// <inheritdoc/>
@@ -48,29 +47,13 @@ public partial class ColorToHexConverter : IValueConverter
     {
         string hexValue = value.ToString()!;
 
-        if (hexValue.StartsWith("#"))
-        {
-            try
-            {
-                return hexValue.ToColor();
-            }
-            catch
-            {
-                // Invalid hex color value provided
-                return DependencyProperty.UnsetValue;
-            }
-        }
-        else
-        {
-            try
-            {
-                return ("#" + hexValue).ToColor();
-            }
-            catch
-            {
-                // Invalid hex color value provided
-                return DependencyProperty.UnsetValue;
-            }
-        }
+        if (!hexValue.StartsWith('#'))
+            hexValue = $"#{hexValue}";
+
+        if (ColorHelper.TryParseHexColor(hexValue, out var color))
+            return color;
+
+        // Invalid hex color value provided
+        return DependencyProperty.UnsetValue;
     }
 }

--- a/components/Helpers/samples/ColorHelper.md
+++ b/components/Helpers/samples/ColorHelper.md
@@ -12,13 +12,48 @@ issue-id: 0
 icon: Assets/ColorHelper.png
 ---
 
-The `ColorHelper` can convert various formats (text names, HTML hex, HSV and HSL) to `Windows.UI.Colors` and back. Some examples:
+The `ColorHelper` contains various methods for color parsing and color manipulation for `Windows.UI.Colors`
+
+## Color parsing 
+
+The `ColorHelper` contains various methods for parsing colors in specific formats, or simply `ParseColor` can be used to auto-detect the format.
+
+Each parsing method has both a "Parse" and "TryParse" pattern version .
 
 ```csharp
-Color color = "#FFFF0000".ToColor();
-Color color = "Red".ToColor();
-string hex = Colors.Red.ToHex();
-HslColor hsl = Colors.Red.ToHsl();
-HsvColor hsv = Colors.Red.ToHsv();
-int i = Colors.Red.ToInt();
+// Parse by hex string
+Color color = ColorHelper.ParseHexColor("#FFFF0000");
+
+// Parse by hsl string
+ColorHelper.ParseHslColor("hsl(0, 1, 0)");
+
+// Try parse by name
+ColorHelper.TryParseColorName("Red", out Color color);
+```
+
+## HSL/HSV Manipulation
+
+The `ColorHelper` package includes methods for manipulating colors in the HSL or HSV color space.
+
+```csharp
+// Adjust a color's hue (to blue)
+color = color.WithHue(240);
+
+// Adjust a color's saturation (to fully saturated)
+color = color.WithSaturation(1);
+```
+
+The package also includes models to store the color as either a HSV or HSL color.
+
+A `Windows.UI.Color` can be converted to an a `HsvColor` or `HslColor` either by using the `.ToHsv()` and `.ToHsl()` methods, or by using an explicit cast on a color.
+
+`HslColor` and `HsvColor` will implicity cast back to a `Windows.UI.Color` when needed.
+
+```csharp
+// Convert to hsl
+Color color;
+var hslColor = (HslColor)color;
+
+// new SolidColorBrush takes a Color, but the HslColor can be implicitly cast to match
+var brush = new SolidColorBrush(hslColor);
 ```

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.UI;
-using System.Globalization;
 using Windows.UI;
 
 namespace CommunityToolkit.WinUI.Helpers;
@@ -135,8 +133,6 @@ public static class ColorExtensions
         return Color.FromArgb(a, r, g, b);
     }
 
-#if NET10_0_OR_GREATER
-
     extension(Color _)
     {
         /// <inheritdoc cref="ColorHelper.TryParseColor(string, out Color)"/>
@@ -259,6 +255,4 @@ public static class ColorExtensions
         /// <inheritdoc cref="Subtract(Color, Color)"/>
         public static Color operator -(Color color1, Color color2) => Subtract(color1, color2);
     }
-
-#endif
 }

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.UI;
+using System.Globalization;
 using Windows.UI;
 
 namespace CommunityToolkit.WinUI.Helpers;
@@ -135,8 +137,44 @@ public static class ColorExtensions
 
 #if NET10_0_OR_GREATER
 
-    extension(Color color)
+    extension(Color _)
     {
+        /// <inheritdoc cref="ColorHelper.TryParseColor(string, out Color)"/>
+        public static bool TryParseColor(string colorString, out Color color) => ColorHelper.TryParseColor(colorString, out color);
+
+        /// <inheritdoc cref="ColorHelper.TryParseHexColor(string, out Color)"/>
+        public static bool TryParseHexColor(string hexString, out Color color) => ColorHelper.TryParseHexColor(hexString, out color);
+
+        /// <inheritdoc cref="ColorHelper.TryParseHslColor(string, out HslColor)"/>
+        public static bool TryParseHslColor(string hslColor, out HslColor color) => ColorHelper.TryParseHslColor(hslColor, out color);
+
+        /// <inheritdoc cref="ColorHelper.TryParseHsvColor(string, out HsvColor)"/>
+        public static bool TryParseHsvColor(string hsvColor, out HsvColor color) => ColorHelper.TryParseHsvColor(hsvColor, out color);
+
+        /// <inheritdoc cref="ColorHelper.TryParseScreenColor(string, out Color)"/>
+        public static bool TryParseScreenColor(string screenColor, out Color color) => ColorHelper.TryParseScreenColor(screenColor, out color);
+
+        /// <inheritdoc cref="ColorHelper.TryParseColorName(string, out Color)"/>
+        public static bool TryParseColorName(string colorName, out Color color) => ColorHelper.TryParseColorName(colorName, out color);
+
+        /// <inheritdoc cref="ColorHelper.ParseColor(string)"/>
+        public static Color ParseColor(string colorString) => ColorHelper.ParseColor(colorString);
+
+        /// <inheritdoc cref="ColorHelper.ParseHexColor(string)"/>
+        public static Color ParseHexColor(string hexColor) => ColorHelper.ParseHexColor(hexColor);
+
+        /// <inheritdoc cref="ColorHelper.ParseHslColor(string)"/>
+        public static HslColor ParseHslColor(string hslColor) => ColorHelper.ParseHslColor(hslColor);
+
+        /// <inheritdoc cref="ColorHelper.ParseHsvColor(string)"/>
+        public static HsvColor ParseHsvColor(string hsvColor) => ColorHelper.ParseHsvColor(hsvColor);
+
+        /// <inheritdoc cref="ColorHelper.ParseScreenColor(string)"/>
+        public static Color ParseScreenColor(string screenColor) => ColorHelper.ParseScreenColor(screenColor);
+
+        /// <inheritdoc cref="ColorHelper.ParseColorName(string)"/>
+        public static Color ParseColorName(string colorName) => ColorHelper.ParseColorName(colorName);
+
         /// <summary>
         /// Gets a <see cref="HsvColor"/> from alpha, hue, saturation, and lightness channel info.
         /// </summary>

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -59,12 +59,12 @@ public static class ColorExtensions
     }
 
     /// <summary>
-    /// Gets a color with the same saturation and value/lightness, but with an adjusted hue.
+    /// Gets a color with the same saturation and value, but with an adjusted hue.
     /// </summary>
     /// <param name="base">The original color.</param>
     /// <param name="hue">The new hue.</param>
-    /// <returns>A <see cref="HsvColor"/> with a new hue and the same saturation and value/lightness.</returns>
-    public static HsvColor Hue(this Color @base, double hue)
+    /// <returns>A <see cref="HsvColor"/> with a new hue and the same saturation and value.</returns>
+    public static HsvColor WithHue(this Color @base, double hue)
     {
         var hsv = (HsvColor)@base;
         hsv.Hue = hue;
@@ -72,12 +72,12 @@ public static class ColorExtensions
     }
 
     /// <summary>
-    /// Gets a color with the same hue and value/lightness, but with an adjusted saturation.
+    /// Gets a color with the same hue and value, but with an adjusted saturation.
     /// </summary>
     /// <param name="base">The original color.</param>
     /// <param name="saturation">The new saturation.</param>
-    /// <returns>A <see cref="HsvColor"/> with a new saturation and the same hue and value/lightness.</returns>
-    public static HsvColor Saturation(this Color @base, double saturation)
+    /// <returns>A <see cref="HsvColor"/> with a new saturation and the same hue and value.</returns>
+    public static HsvColor WithSaturation(this Color @base, double saturation)
     {
         var hsv = (HsvColor)@base;
         hsv.Saturation = saturation;
@@ -90,7 +90,7 @@ public static class ColorExtensions
     /// <param name="base">The original color.</param>
     /// <param name="value">The new value.</param>
     /// <returns>A <see cref="HsvColor"/> with a new value and the same hue and saturation.</returns>
-    public static HsvColor Value(this Color @base, double value)
+    public static HsvColor WithValue(this Color @base, double value)
     {
         var hsv = (HsvColor)@base;
         hsv.Value = value;
@@ -103,7 +103,7 @@ public static class ColorExtensions
     /// <param name="base">The original color.</param>
     /// <param name="lightness">The new lightness.</param>
     /// <returns>A <see cref="HsvColor"/> with a new lightness and the same hue and saturation.</returns>
-    public static HslColor Lightness(this Color @base, double lightness)
+    public static HslColor WithLightness(this Color @base, double lightness)
     {
         var hsl = (HslColor)@base;
         hsl.Lightness = lightness;
@@ -179,7 +179,7 @@ public static class ColorExtensions
         /// Adds two colors.
         /// </summary>
         /// <remarks>
-        /// Simple RGB summation, with each channel clamped seperately.
+        /// Simple RGB summation, with each channel clamped seperately. Alpha is NOT included, and will always be opaque.
         /// </remarks>
         /// <param name="color1">The first color.</param>
         /// <param name="color2">The second color.</param>
@@ -188,19 +188,18 @@ public static class ColorExtensions
         {
             static byte ClampedAdd(byte b1, byte b2) => (byte)int.Min(b1 + b2, 255);
 
-            var a = ClampedAdd(color1.A, color2.A);
             var r = ClampedAdd(color1.R, color2.R);
             var g = ClampedAdd(color1.G, color2.G);
             var b = ClampedAdd(color1.B, color2.B);
 
-            return Color.FromArgb(a, r, g, b);
+            return Color.FromArgb(255, r, g, b);
         }
 
         /// <summary>
         /// Subtracts a color from another.
         /// </summary>
         /// <remarks>
-        /// Simple RGB subtraction, with each channel clamped seperately.
+        /// Simple RGB subtraction, with each channel clamped seperately. Alpha is NOT included, and will always be opaque.
         /// </remarks>
         /// <param name="color1">The first color.</param>
         /// <param name="color2">The second color.</param>
@@ -209,19 +208,18 @@ public static class ColorExtensions
         {
             static byte ClampedSubtract(byte b1, byte b2) => (byte)int.Max(b1 - b2, 0);
 
-            var a = ClampedSubtract(color1.A, color2.A);
             var r = ClampedSubtract(color1.R, color2.R);
             var g = ClampedSubtract(color1.G, color2.G);
             var b = ClampedSubtract(color1.B, color2.B);
 
-            return Color.FromArgb(a, r, g, b);
+            return Color.FromArgb(255, r, g, b);
         }
 
         /// <inheritdoc cref="Add(Color, Color)"/>
         public static Color operator +(Color color1, Color color2) => Add(color1, color2);
 
         /// <inheritdoc cref="Subtract(Color, Color)"/>
-        public static Color operator -(Color color1, Color color2) => Add(color1, color2);
+        public static Color operator -(Color color1, Color color2) => Subtract(color1, color2);
     }
 
 #endif

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI;
+
+namespace CommunityToolkit.WinUI.Helpers;
+
+/// <summary>
+/// A class containing extensions methods for <see cref="Color"/>
+/// </summary>
+public static class ColorExtensions
+{
+    /// <summary>
+    /// Converts a <see cref="Color"/> to a premultiplied Int32 - 4 byte ARGB structure.
+    /// </summary>
+    /// <param name="color">The color to convert.</param>
+    /// <returns>The int representation of the color.</returns>
+    public static int ToInt(this Color color)
+    {
+        var a = color.A + 1;
+        var col = (color.A << 24) | ((byte)((color.R * a) >> 8) << 16) | ((byte)((color.G * a) >> 8) << 8) | (byte)((color.B * a) >> 8);
+        return col;
+    }
+
+    /// <summary>
+    /// Converts a <see cref="Color"/> to an <see cref="HslColor"/>.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to convert.</param>
+    /// <returns>The converted <see cref="HslColor"/>.</returns>
+    public static HslColor ToHsl(this Color color) => (HslColor)color;
+
+    /// <summary>
+    /// Converts a <see cref="Color"/> to an <see cref="HsvColor"/>.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to convert.</param>
+    /// <returns>The converted <see cref="HsvColor"/>.</returns>
+    public static HsvColor ToHsv(this Color color) => (HsvColor)color;
+}

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -36,4 +36,39 @@ public static class ColorExtensions
     /// <param name="color">The <see cref="Color"/> to convert.</param>
     /// <returns>The converted <see cref="HsvColor"/>.</returns>
     public static HsvColor ToHsv(this Color color) => (HsvColor)color;
+
+#if NET10_0_OR_GREATER
+
+    extension(Color color)
+    {
+        /// <summary>
+        /// Gets a <see cref="HsvColor"/> from alpha, hue, saturation, and lightness channel info.
+        /// </summary>
+        /// <remarks>
+        /// This returns a <see cref="HslColor"/> in order to avoid unneccesary conversions.
+        /// However, the <see cref="HslColor"/> will be implicitly cast to a <see cref="Color"/> if needed.
+        /// </remarks>
+        /// <param name="h">The color's hue.</param>
+        /// <param name="s">The color's saturation.</param>
+        /// <param name="l">The color's lightness.</param>
+        /// <param name="a">The color's alpha value.</param>
+        /// <returns>The color as a <see cref="HslColor"/>.</returns>
+        public static HslColor FromAhsl(double a, double h, double s, double l) => HslColor.Create(h, s, l, a);
+
+        /// <summary>
+        /// Gets a <see cref="HsvColor"/> from alpha, hue, saturation, and value channel info.
+        /// </summary>
+        /// <remarks>
+        /// This returns a <see cref="HsvColor"/> in order to avoid unneccesary conversions.
+        /// However, the <see cref="HsvColor"/> will be implicitly cast to a <see cref="Color"/> if needed.
+        /// </remarks>
+        /// <param name="h">The color's hue.</param>
+        /// <param name="s">The color's saturation.</param>
+        /// <param name="v">The color's value.</param>
+        /// <param name="a">The color's alpha value.</param>
+        /// <returns>The color as a <see cref="HsvColor"/>.</returns>
+        public static HsvColor FromAhsv(double a, double h, double s, double v) => HsvColor.Create(h, s, v, a);
+    }
+
+#endif
 }

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel.DataAnnotations;
 using Windows.UI;
 
 namespace CommunityToolkit.WinUI.Helpers;
@@ -37,6 +38,42 @@ public static class ColorExtensions
     /// <returns>The converted <see cref="HsvColor"/>.</returns>
     public static HsvColor ToHsv(this Color color) => (HsvColor)color;
 
+    /// <inheritdoc cref="AlphaOver(Color, Color, double)"/>
+    public static Color AlphaOver(this Color @base, Color overlay)
+        => AlphaOver(@base, overlay, (double)overlay.A / 255);
+
+    /// <summary>
+    /// Performs an AlphaOverlay between two colors.
+    /// </summary>
+    /// <param name="base">The base color.</param>
+    /// <param name="overlay">The overlay color.</param>
+    /// <param name="alpha">The alpha factor.</param>
+    /// <returns>The resulting color from alpha overlaying <paramref name="overlay"/> over <paramref name="base"/>.</returns>
+    public static Color AlphaOver(this Color @base, Color overlay, double alpha)
+    {
+        // Find the color's mix, using the overlay's opacity as a factor
+        var mix = MixColors(@base, overlay, alpha);
+
+        // Restore the alpha to match the base
+        mix.A = @base.A;
+        return mix;
+    }
+
+    private static Color MixColors(Color color1, Color color2, double factor)
+    {
+        // Formula for linearly blending a channel
+        var invFactor = 1 - factor;
+        byte Blend(byte c1, byte c2) => (byte)Math.Round((c1 * factor) + (c2 * invFactor));
+
+        // Blend each channel
+        var a = Blend(color1.A, color2.A);
+        var r = Blend(color1.R, color2.R);
+        var g = Blend(color1.G, color2.G);
+        var b = Blend(color1.B, color2.B);
+
+        return Color.FromArgb(a, r, g, b);
+    }
+
 #if NET10_0_OR_GREATER
 
     extension(Color color)
@@ -68,6 +105,16 @@ public static class ColorExtensions
         /// <param name="a">The color's alpha value.</param>
         /// <returns>The color as a <see cref="HsvColor"/>.</returns>
         public static HsvColor FromAhsv(double a, double h, double s, double v) => HsvColor.Create(h, s, v, a);
+
+        /// <summary>
+        /// Mixes two colors
+        /// </summary>
+        /// <param name="color1"></param>
+        /// <param name="color2"></param>
+        /// <param name="factor"></param>
+        /// <returns></returns>
+        public static Color Mix(Color color1, Color color2, double factor)
+            => MixColors(color1, color2, factor);
     }
 
 #endif

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -61,12 +61,12 @@ public static class ColorExtensions
     /// <summary>
     /// Gets a color with the same saturation and value, but with an adjusted hue.
     /// </summary>
-    /// <param name="base">The original color.</param>
+    /// <param name="original">The original color.</param>
     /// <param name="hue">The new hue.</param>
     /// <returns>A <see cref="HsvColor"/> with a new hue and the same saturation and value.</returns>
-    public static HsvColor WithHue(this Color @base, double hue)
+    public static HsvColor WithHue(this Color original, double hue)
     {
-        var hsv = (HsvColor)@base;
+        var hsv = (HsvColor)original;
         hsv.Hue = hue;
         return hsv;
     }
@@ -74,12 +74,12 @@ public static class ColorExtensions
     /// <summary>
     /// Gets a color with the same hue and value, but with an adjusted saturation.
     /// </summary>
-    /// <param name="base">The original color.</param>
+    /// <param name="original">The original color.</param>
     /// <param name="saturation">The new saturation.</param>
     /// <returns>A <see cref="HsvColor"/> with a new saturation and the same hue and value.</returns>
-    public static HsvColor WithSaturation(this Color @base, double saturation)
+    public static HsvColor WithSaturation(this Color original, double saturation)
     {
-        var hsv = (HsvColor)@base;
+        var hsv = (HsvColor)original;
         hsv.Saturation = saturation;
         return hsv;
     }
@@ -87,12 +87,12 @@ public static class ColorExtensions
     /// <summary>
     /// Gets a color with the same hue and saturation, but with an adjusted saturation.
     /// </summary>
-    /// <param name="base">The original color.</param>
+    /// <param name="original">The original color.</param>
     /// <param name="value">The new value.</param>
     /// <returns>A <see cref="HsvColor"/> with a new value and the same hue and saturation.</returns>
-    public static HsvColor WithValue(this Color @base, double value)
+    public static HsvColor WithValue(this Color original, double value)
     {
-        var hsv = (HsvColor)@base;
+        var hsv = (HsvColor)original;
         hsv.Value = value;
         return hsv;
     }
@@ -100,12 +100,12 @@ public static class ColorExtensions
     /// <summary>
     /// Gets a color with the same hue and saturation, but with an adjusted lightness.
     /// </summary>
-    /// <param name="base">The original color.</param>
+    /// <param name="original">The original color.</param>
     /// <param name="lightness">The new lightness.</param>
     /// <returns>A <see cref="HsvColor"/> with a new lightness and the same hue and saturation.</returns>
-    public static HslColor WithLightness(this Color @base, double lightness)
+    public static HslColor WithLightness(this Color original, double lightness)
     {
-        var hsl = (HslColor)@base;
+        var hsl = (HslColor)original;
         hsl.Lightness = lightness;
         return hsl;
     }

--- a/components/Helpers/src/ColorHelper/ColorExtensions.cs
+++ b/components/Helpers/src/ColorHelper/ColorExtensions.cs
@@ -64,7 +64,7 @@ public static class ColorExtensions
     /// <param name="original">The original color.</param>
     /// <param name="hue">The new hue.</param>
     /// <returns>A <see cref="HsvColor"/> with a new hue and the same saturation and value.</returns>
-    public static HsvColor WithHue(this Color original, double hue)
+    public static HsvColor WithHue(this Color original, float hue)
     {
         var hsv = (HsvColor)original;
         hsv.Hue = hue;
@@ -77,7 +77,7 @@ public static class ColorExtensions
     /// <param name="original">The original color.</param>
     /// <param name="saturation">The new saturation.</param>
     /// <returns>A <see cref="HsvColor"/> with a new saturation and the same hue and value.</returns>
-    public static HsvColor WithSaturation(this Color original, double saturation)
+    public static HsvColor WithSaturation(this Color original, float saturation)
     {
         var hsv = (HsvColor)original;
         hsv.Saturation = saturation;
@@ -90,7 +90,7 @@ public static class ColorExtensions
     /// <param name="original">The original color.</param>
     /// <param name="value">The new value.</param>
     /// <returns>A <see cref="HsvColor"/> with a new value and the same hue and saturation.</returns>
-    public static HsvColor WithValue(this Color original, double value)
+    public static HsvColor WithValue(this Color original, float value)
     {
         var hsv = (HsvColor)original;
         hsv.Value = value;
@@ -103,7 +103,7 @@ public static class ColorExtensions
     /// <param name="original">The original color.</param>
     /// <param name="lightness">The new lightness.</param>
     /// <returns>A <see cref="HsvColor"/> with a new lightness and the same hue and saturation.</returns>
-    public static HslColor WithLightness(this Color original, double lightness)
+    public static HslColor WithLightness(this Color original, float lightness)
     {
         var hsl = (HslColor)original;
         hsl.Lightness = lightness;
@@ -183,7 +183,7 @@ public static class ColorExtensions
         /// <param name="l">The color's lightness.</param>
         /// <param name="a">The color's alpha value.</param>
         /// <returns>The color as a <see cref="HslColor"/>.</returns>
-        public static HslColor FromAhsl(double a, double h, double s, double l) => HslColor.Create(h, s, l, a);
+        public static HslColor FromAhsl(float a, float h, float s, float l) => HslColor.Create(h, s, l, a);
 
         /// <summary>
         /// Gets a <see cref="HsvColor"/> from alpha, hue, saturation, and value channel info.
@@ -197,7 +197,7 @@ public static class ColorExtensions
         /// <param name="v">The color's value.</param>
         /// <param name="a">The color's alpha value.</param>
         /// <returns>The color as a <see cref="HsvColor"/>.</returns>
-        public static HsvColor FromAhsv(double a, double h, double s, double v) => HsvColor.Create(h, s, v, a);
+        public static HsvColor FromAhsv(float a, float h, float s, float v) => HsvColor.Create(h, s, v, a);
 
         /// <summary>
         /// Mixes two colors using a factor for deciding how much influence each color has.

--- a/components/Helpers/src/ColorHelper/ColorHelper.Obsolete.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.Obsolete.cs
@@ -9,6 +9,15 @@ namespace CommunityToolkit.WinUI.Helpers;
 public static partial class ColorHelper
 {
     /// <summary>
+    /// Creates a <see cref="Color"/> from a XAML color string.
+    /// Any format used in XAML should work.
+    /// </summary>
+    /// <param name="colorString">The XAML color string.</param>
+    /// <returns>The created <see cref="Color"/>.</returns>
+    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with ColorHelper.ParseColor(string colorString).")]
+    public static Color ToColor(this string colorString) => ParseColor(colorString);
+
+    /// <summary>
     /// Creates a <see cref="Color"/> from the specified hue, saturation, lightness, and alpha values.
     /// </summary>
     /// <param name="hue">0..360 range hue</param>
@@ -31,4 +40,12 @@ public static partial class ColorHelper
     [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with (Color)HsvColor.Create().")]
     public static Color FromHsv(double hue, double saturation, double value, double alpha = 1.0)
         => HsvColor.Create(hue, saturation, value, alpha);
+
+    /// <summary>
+    /// Converts a <see cref="Color"/> to a hexadecimal string representation.
+    /// </summary>
+    /// <param name="color">The color to convert.</param>
+    /// <returns>The hexadecimal string representation of the color.</returns>
+    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with .ToString().")]
+    public static string ToHex(this Color color) => color.ToString();
 }

--- a/components/Helpers/src/ColorHelper/ColorHelper.Obsolete.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.Obsolete.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI;
+
+namespace CommunityToolkit.WinUI.Helpers;
+
+public static partial class ColorHelper
+{
+    /// <summary>
+    /// Creates a <see cref="Color"/> from the specified hue, saturation, lightness, and alpha values.
+    /// </summary>
+    /// <param name="hue">0..360 range hue</param>
+    /// <param name="saturation">0..1 range saturation</param>
+    /// <param name="lightness">0..1 range lightness</param>
+    /// <param name="alpha">0..1 alpha</param>
+    /// <returns>The created <see cref="Color"/>.</returns>
+    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with (Color)HslColor.Create().")]
+    public static Color FromHsl(double hue, double saturation, double lightness, double alpha = 1.0)
+        => HslColor.Create(hue, saturation, lightness, alpha);
+
+    /// <summary>
+    /// Creates a <see cref="Color"/> from the specified hue, saturation, value, and alpha values.
+    /// </summary>
+    /// <param name="hue">0..360 range hue</param>
+    /// <param name="saturation">0..1 range saturation</param>
+    /// <param name="value">0..1 range value</param>
+    /// <param name="alpha">0..1 alpha</param>
+    /// <returns>The created <see cref="Color"/>.</returns>
+    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with (Color)HsvColor.Create().")]
+    public static Color FromHsv(double hue, double saturation, double value, double alpha = 1.0)
+        => HsvColor.Create(hue, saturation, value, alpha);
+}

--- a/components/Helpers/src/ColorHelper/ColorHelper.Obsolete.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.Obsolete.cs
@@ -27,7 +27,7 @@ public static partial class ColorHelper
     /// <returns>The created <see cref="Color"/>.</returns>
     [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with (Color)HslColor.Create().")]
     public static Color FromHsl(double hue, double saturation, double lightness, double alpha = 1.0)
-        => HslColor.Create(hue, saturation, lightness, alpha);
+        => HslColor.Create((float)hue, (float)saturation, (float)lightness, alpha);
 
     /// <summary>
     /// Creates a <see cref="Color"/> from the specified hue, saturation, value, and alpha values.
@@ -39,7 +39,7 @@ public static partial class ColorHelper
     /// <returns>The created <see cref="Color"/>.</returns>
     [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with (Color)HsvColor.Create().")]
     public static Color FromHsv(double hue, double saturation, double value, double alpha = 1.0)
-        => HsvColor.Create(hue, saturation, value, alpha);
+        => HsvColor.Create((float)hue, (float)saturation, (float)value, (float)alpha);
 
     /// <summary>
     /// Converts a <see cref="Color"/> to a hexadecimal string representation.

--- a/components/Helpers/src/ColorHelper/ColorHelper.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.cs
@@ -15,7 +15,7 @@ namespace CommunityToolkit.WinUI.Helpers;
 /// <summary>
 /// This class provides static helper methods for colors.
 /// </summary>
-public static class ColorHelper
+public static partial class ColorHelper
 {
     /// <summary>
     /// Creates a <see cref="Color"/> from a XAML color string.
@@ -187,7 +187,7 @@ public static class ColorHelper
 
         double lightness = 0.5 * (max + min);
         double saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
-        HslColor ret;
+        HslColor ret = default;
         ret.H = 60 * h1;
         ret.S = saturation;
         ret.L = lightness;
@@ -231,7 +231,7 @@ public static class ColorHelper
         }
 
         double saturation = chroma == 0 ? 0 : chroma / max;
-        HsvColor ret;
+        HsvColor ret = default;
         ret.H = 60 * h1;
         ret.S = saturation;
         ret.V = max;
@@ -239,129 +239,21 @@ public static class ColorHelper
         return ret;
     }
 
-    /// <summary>
-    /// Creates a <see cref="Color"/> from the specified hue, saturation, lightness, and alpha values.
-    /// </summary>
-    /// <param name="hue">0..360 range hue</param>
-    /// <param name="saturation">0..1 range saturation</param>
-    /// <param name="lightness">0..1 range lightness</param>
-    /// <param name="alpha">0..1 alpha</param>
-    /// <returns>The created <see cref="Color"/>.</returns>
-    public static Color FromHsl(double hue, double saturation, double lightness, double alpha = 1.0)
+    internal static Color FromHueChroma(double h1, double chroma, double x, double m, double alpha)
     {
-        if (hue < 0 || hue > 360)
-        {
-            throw new ArgumentOutOfRangeException(nameof(hue));
-        }
+        // This code is shared between both the conversion of
+        // both HSL and HSV to RGB.
 
-        double chroma = (1 - Math.Abs((2 * lightness) - 1)) * saturation;
-        double h1 = hue / 60;
-        double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
-        double m = lightness - (0.5 * chroma);
         double r1, g1, b1;
-
-        if (h1 < 1)
+        (r1, g1, b1) = h1 switch
         {
-            r1 = chroma;
-            g1 = x;
-            b1 = 0;
-        }
-        else if (h1 < 2)
-        {
-            r1 = x;
-            g1 = chroma;
-            b1 = 0;
-        }
-        else if (h1 < 3)
-        {
-            r1 = 0;
-            g1 = chroma;
-            b1 = x;
-        }
-        else if (h1 < 4)
-        {
-            r1 = 0;
-            g1 = x;
-            b1 = chroma;
-        }
-        else if (h1 < 5)
-        {
-            r1 = x;
-            g1 = 0;
-            b1 = chroma;
-        }
-        else
-        {
-            r1 = chroma;
-            g1 = 0;
-            b1 = x;
-        }
-
-        byte r = (byte)(255 * (r1 + m));
-        byte g = (byte)(255 * (g1 + m));
-        byte b = (byte)(255 * (b1 + m));
-        byte a = (byte)(255 * alpha);
-
-        return Color.FromArgb(a, r, g, b);
-    }
-
-    /// <summary>
-    /// Creates a <see cref="Color"/> from the specified hue, saturation, value, and alpha values.
-    /// </summary>
-    /// <param name="hue">0..360 range hue</param>
-    /// <param name="saturation">0..1 range saturation</param>
-    /// <param name="value">0..1 range value</param>
-    /// <param name="alpha">0..1 alpha</param>
-    /// <returns>The created <see cref="Color"/>.</returns>
-    public static Color FromHsv(double hue, double saturation, double value, double alpha = 1.0)
-    {
-        if (hue < 0 || hue > 360)
-        {
-            throw new ArgumentOutOfRangeException(nameof(hue));
-        }
-
-        double chroma = value * saturation;
-        double h1 = hue / 60;
-        double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
-        double m = value - chroma;
-        double r1, g1, b1;
-
-        if (h1 < 1)
-        {
-            r1 = chroma;
-            g1 = x;
-            b1 = 0;
-        }
-        else if (h1 < 2)
-        {
-            r1 = x;
-            g1 = chroma;
-            b1 = 0;
-        }
-        else if (h1 < 3)
-        {
-            r1 = 0;
-            g1 = chroma;
-            b1 = x;
-        }
-        else if (h1 < 4)
-        {
-            r1 = 0;
-            g1 = x;
-            b1 = chroma;
-        }
-        else if (h1 < 5)
-        {
-            r1 = x;
-            g1 = 0;
-            b1 = chroma;
-        }
-        else
-        {
-            r1 = chroma;
-            g1 = 0;
-            b1 = x;
-        }
+            < 1 => (chroma, x, 0d),
+            < 2 => (x,  chroma, 0d),
+            < 3 => (0d, chroma, x),
+            < 4 => (0d, x, chroma),
+            < 5 => (x, 0d, chroma),
+            _ => (chroma, 0d, x),
+        };
 
         byte r = (byte)(255 * (r1 + m));
         byte g = (byte)(255 * (g1 + m));

--- a/components/Helpers/src/ColorHelper/ColorHelper.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.cs
@@ -19,6 +19,165 @@ namespace CommunityToolkit.WinUI.Helpers;
 public static partial class ColorHelper
 {
     /// <summary>
+    /// Attempts to parse a string as a color.
+    /// </summary>
+    /// <remarks>
+    /// Any format used in XAML should work.
+    /// </remarks>
+    /// <param name="colorString">The string to parse.</param>
+    /// <param name="color">The resulting color.</param>
+    /// <returns>Whether or not the parse succeeded.</returns>
+    public static bool TryParseColor(string colorString, out Color color)
+    {
+        color = default;
+
+        if (string.IsNullOrEmpty(colorString))
+            return false;
+
+        // Try as hex
+        if (TryParseHexColor(colorString, out color))
+            return true;
+
+        // Try as screen color
+        if (TryParseScreenColor(colorString, out color))
+            return true;
+
+        if (TryParseColorName(colorString, out color))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to parse a string as a hex color.
+    /// </summary>
+    /// <param name="hexString">The string to parse.</param>
+    /// <param name="color">The resulting color.</param>
+    /// <returns>Whether or not the parse succeeded.</returns>
+    public static bool TryParseHexColor(string hexString, out Color color)
+    {
+        color = default;
+
+        // Ensure string begins with '#'
+        // and is long enough to not break later in the parser.
+        if (string.IsNullOrEmpty(hexString) ||
+            hexString.Length < 2 ||
+            hexString[0] != '#')
+            return false;
+
+        // Convert base 16 string to uint
+        if(!uint.TryParse(hexString[1..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var cuint))
+            return false;
+
+        // Extract 4 bytes
+        byte b3 = (byte)(cuint >> 24);
+        byte b2 = (byte)((cuint >> 16) & 0xff);
+        byte b1 = (byte)((cuint >> 8) & 0xff);
+        byte b0 = (byte)(cuint & 0xff);
+
+        // Extract 4 half-bytes
+        byte h3 = (byte)(cuint >> 12);
+        byte h2 = (byte)((cuint >> 8) & 0xf);
+        byte h1 = (byte)((cuint >> 4) & 0xf);
+        byte h0 = (byte)(cuint & 0xf);
+        h3 = (byte)(h3 << 4 | h3);
+        h2 = (byte)(h2 << 4 | h2);
+        h1 = (byte)(h1 << 4 | h1);
+        h0 = (byte)(h0 << 4 | h0);
+
+        // Select bytes based on string length
+        switch (hexString.Length)
+        {
+            // #AaRrGgBb
+            case 9:
+                color = Color.FromArgb(b3, b2, b1, b0);
+                return true;
+            // #RrGgBb
+            case 7:
+                color = Color.FromArgb(255, b2, b1, b0);
+                return true;
+            // #ARGB
+            case 5:
+                color = Color.FromArgb(h3, h2, h1, h0);
+                return true;
+            // #RGB
+            case 4:
+                color = Color.FromArgb(255, h2, h1, h0);
+                return true;
+            // Invalid format
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to parse a string as a screen color.
+    /// </summary>
+    /// <param name="screenColor">The string to parse.</param>
+    /// <param name="color">The resulting color.</param>
+    /// <returns>Whether or not the parse succeeded.</returns>
+    public static bool TryParseScreenColor(string screenColor, out Color color)
+    {
+        color = default;
+
+        // Ensure the string begins with "sc#"
+        if (screenColor.Length < 3 || screenColor[0..3] != "sc#")
+            return false;
+
+        // Get arguments
+        screenColor = screenColor[3..];
+        var values = screenColor.Split(',');
+
+        // Parse the arguments from string doubles into bytes
+        var args = new byte[values.Length];
+        for (int i = 0; i <  values.Length; i++)
+        {
+            if (!double.TryParse(values[i], out var arg))
+                return false;
+
+            args[i] = (byte)(arg * 255);
+        }
+
+        // Assign channel data based on arguments
+        switch (args.Length)
+        {
+            // sc#Alpha,Red,Green,Blue
+            case 4:
+                color = Color.FromArgb(args[0], args[1], args[2], args[3]);
+                return true;
+            // sc#Red,Green,Blue
+            case 3:
+                color = Color.FromArgb(255, args[0], args[1], args[2]);
+                return true;
+            // Invalid format
+            default:
+                return false;
+        }
+    }
+    
+    /// <summary>
+    /// Attempts to parse a string color name.
+    /// </summary>
+    /// <param name="colorName">The color name.</param>
+    /// <param name="color">The resulting color.</param>
+    /// <returns>Whether or not the parse succeeded.</returns>
+    public static bool TryParseColorName(string colorName, out Color color)
+    {
+        color = default;
+        
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+        var prop = typeof(Colors).GetTypeInfo().GetDeclaredProperty(colorName);
+        if (prop != null)
+        {
+            color = (Color)prop.GetValue(null);
+            return true;
+        }
+#pragma warning restore CS8605 // Unboxing a possibly null value.
+
+        return false;
+    }
+
+    /// <summary>
     /// Creates a <see cref="Color"/> from a XAML color string.
     /// Any format used in XAML should work.
     /// </summary>
@@ -26,83 +185,50 @@ public static partial class ColorHelper
     /// <returns>The created <see cref="Color"/>.</returns>
     public static Color ParseColor(string colorString)
     {
-        if (string.IsNullOrEmpty(colorString))
-        {
-            ThrowArgumentException();
-        }
+        if (TryParseColor(colorString, out var color))
+            return color;
 
-        if (colorString[0] == '#')
-        {
-            var cuint = Convert.ToUInt32(colorString[1..], 16);
+        throw new FormatException($"The string '{colorString}' could not be parsed as a string.");
+    }
 
-            // 4 bytes
-            byte b3 = (byte)(cuint >> 24);
-            byte b2 = (byte)((cuint >> 16) & 0xff);
-            byte b1 = (byte)((cuint >> 8) & 0xff);
-            byte b0 = (byte)(cuint & 0xff);
+    /// <summary>
+    /// Parses a hexadecimal color string into a <see cref="Color"/>.
+    /// </summary>
+    /// <param name="hexColor">The hex color string.</param>
+    /// <returns>The resulting <see cref="Color"/>.</returns>
+    public static Color ParseHexColor(string hexColor)
+    {
+        if (TryParseHexColor(hexColor, out var color))
+            return color;
 
-            // 4 half-bytes
-            byte h3 = (byte)(cuint >> 12);
-            byte h2 = (byte)((cuint >> 8) & 0xf);
-            byte h1 = (byte)((cuint >> 4) & 0xf);
-            byte h0 = (byte)(cuint & 0xf);
-            h3 = (byte)(h3 << 4 | h3);
-            h2 = (byte)(h2 << 4 | h2);
-            h1 = (byte)(h1 << 4 | h1);
-            h0 = (byte)(h0 << 4 | h0);
+        throw new FormatException($"The string '{hexColor}' could not be parsed as a hex color.");
+    }
 
-            byte r, g, b, a;
-            (a, r, g, b) = colorString.Length switch
-            {
-                9 => (b3, b2, b1, b0),
-                7 => ((byte)255, b2, b1, b0),
-                5 => (h3, h2, h1, h0),
-                4 => ((byte)255, h2, h1, h0),
-                _ => ThrowFormatException<(byte, byte, byte, byte)>(),
-            };
+    /// <summary>
+    /// Parses a screen color string into a <see cref="Color"/>.
+    /// </summary>
+    /// <param name="screenColor">The screen color string.</param>
+    /// <returns>The resulting <see cref="Color"/>.</returns>
+    public static Color ParseScreenColor(string screenColor)
+    {
+        if (TryParseScreenColor(screenColor, out var color))
+            return color;
 
-            return Color.FromArgb(a, r, g, b);
-        }
+        throw new FormatException($"The string '{screenColor}' is not a valid ScreenColor string");
+    }
 
-        if (colorString.Length > 3 && colorString[0] == 's' && colorString[1] == 'c' && colorString[2] == '#')
-        {
-            var values = colorString.Split(',');
+    /// <summary>
+    /// Parses a color by name.
+    /// </summary>
+    /// <param name="colorName">The color's name.</param>
+    /// <returns>The resulting <see cref="Color"/>.</returns>
+    /// <exception cref="ArgumentException">Throws if the color name is not recognized.</exception>
+    public static Color ParseColorName(string colorName)
+    {
+        if (TryParseColorName(colorName, out var color))
+            return color;
 
-            if (values.Length == 4)
-            {
-                var scA = double.Parse(values[0].Substring(3), CultureInfo.InvariantCulture);
-                var scR = double.Parse(values[1], CultureInfo.InvariantCulture);
-                var scG = double.Parse(values[2], CultureInfo.InvariantCulture);
-                var scB = double.Parse(values[3], CultureInfo.InvariantCulture);
-
-                return Color.FromArgb((byte)(scA * 255), (byte)(scR * 255), (byte)(scG * 255), (byte)(scB * 255));
-            }
-
-            if (values.Length == 3)
-            {
-                var scR = double.Parse(values[0].Substring(3), CultureInfo.InvariantCulture);
-                var scG = double.Parse(values[1], CultureInfo.InvariantCulture);
-                var scB = double.Parse(values[2], CultureInfo.InvariantCulture);
-
-                return Color.FromArgb(255, (byte)(scR * 255), (byte)(scG * 255), (byte)(scB * 255));
-            }
-
-            return ThrowFormatException<Color>();
-        }
-
-        var prop = typeof(Colors).GetTypeInfo().GetDeclaredProperty(colorString);
-
-        if (prop != null)
-        {
-#pragma warning disable CS8605 // Unboxing a possibly null value.
-            return (Color)prop.GetValue(null);
-#pragma warning restore CS8605 // Unboxing a possibly null value.
-        }
-
-        return ThrowFormatException<Color>();
-
-        static void ThrowArgumentException() => throw new ArgumentException("The parameter \"colorString\" must not be null or empty.");
-        static T ThrowFormatException<T>() => throw new FormatException("The parameter \"colorString\" is not a recognized Color format.");
+        throw new FormatException($"The name '{colorName}' not a valid color");
     }
 
     internal static (double h1, double chroma) CalculateHueAndChroma(Color color, out double min, out double max, out double alpha)
@@ -114,7 +240,7 @@ public static partial class ColorHelper
         var g = (double)color.G / 255;
         var b = (double)color.B / 255;
         alpha = (double)color.A / 255;
-        
+
         max = Math.Max(Math.Max(r, g), b);
         min = Math.Min(Math.Min(r, g), b);
         var chroma = max - min;
@@ -129,7 +255,8 @@ public static partial class ColorHelper
         {
             // Red is max
             h1 = ((g - b) / chroma + 6) % 6;
-        } else if (max == g)
+        }
+        else if (max == g)
         {
             // Green is max
             h1 = 2 + ((b - r) / chroma);
@@ -152,7 +279,7 @@ public static partial class ColorHelper
         (r1, g1, b1) = h1 switch
         {
             < 1 => (chroma, x, 0d),
-            < 2 => (x,  chroma, 0d),
+            < 2 => (x, chroma, 0d),
             < 3 => (0d, chroma, x),
             < 4 => (0d, x, chroma),
             < 5 => (x, 0d, chroma),

--- a/components/Helpers/src/ColorHelper/ColorHelper.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.cs
@@ -33,59 +33,35 @@ public static partial class ColorHelper
 
         if (colorString[0] == '#')
         {
-            switch (colorString.Length)
+            var cuint = Convert.ToUInt32(colorString[1..], 16);
+
+            // 4 bytes
+            byte b3 = (byte)(cuint >> 24);
+            byte b2 = (byte)((cuint >> 16) & 0xff);
+            byte b1 = (byte)((cuint >> 8) & 0xff);
+            byte b0 = (byte)(cuint & 0xff);
+
+            // 4 half-bytes
+            byte h3 = (byte)(cuint >> 12);
+            byte h2 = (byte)((cuint >> 8) & 0xf);
+            byte h1 = (byte)((cuint >> 4) & 0xf);
+            byte h0 = (byte)(cuint & 0xf);
+            h3 = (byte)(h3 << 4 | h3);
+            h2 = (byte)(h2 << 4 | h2);
+            h1 = (byte)(h1 << 4 | h1);
+            h0 = (byte)(h0 << 4 | h0);
+
+            byte r, g, b, a;
+            (a, r, g, b) = colorString.Length switch
             {
-                case 9:
-                {
-                    var cuint = Convert.ToUInt32(colorString.Substring(1), 16);
-                    var a = (byte)(cuint >> 24);
-                    var r = (byte)((cuint >> 16) & 0xff);
-                    var g = (byte)((cuint >> 8) & 0xff);
-                    var b = (byte)(cuint & 0xff);
+                9 => (b3, b2, b1, b0),
+                7 => ((byte)255, b2, b1, b0),
+                5 => (h3, h2, h1, h0),
+                4 => ((byte)255, h2, h1, h0),
+                _ => ThrowFormatException<(byte, byte, byte, byte)>(),
+            };
 
-                    return Color.FromArgb(a, r, g, b);
-                }
-
-                case 7:
-                {
-                    var cuint = Convert.ToUInt32(colorString.Substring(1), 16);
-                    var r = (byte)((cuint >> 16) & 0xff);
-                    var g = (byte)((cuint >> 8) & 0xff);
-                    var b = (byte)(cuint & 0xff);
-
-                    return Color.FromArgb(255, r, g, b);
-                }
-
-                case 5:
-                {
-                    var cuint = Convert.ToUInt16(colorString.Substring(1), 16);
-                    var a = (byte)(cuint >> 12);
-                    var r = (byte)((cuint >> 8) & 0xf);
-                    var g = (byte)((cuint >> 4) & 0xf);
-                    var b = (byte)(cuint & 0xf);
-                    a = (byte)(a << 4 | a);
-                    r = (byte)(r << 4 | r);
-                    g = (byte)(g << 4 | g);
-                    b = (byte)(b << 4 | b);
-
-                    return Color.FromArgb(a, r, g, b);
-                }
-
-                case 4:
-                {
-                    var cuint = Convert.ToUInt16(colorString.Substring(1), 16);
-                    var r = (byte)((cuint >> 8) & 0xf);
-                    var g = (byte)((cuint >> 4) & 0xf);
-                    var b = (byte)(cuint & 0xf);
-                    r = (byte)(r << 4 | r);
-                    g = (byte)(g << 4 | g);
-                    b = (byte)(b << 4 | b);
-
-                    return Color.FromArgb(255, r, g, b);
-                }
-
-                default: return ThrowFormatException();
-            }
+            return Color.FromArgb(a, r, g, b);
         }
 
         if (colorString.Length > 3 && colorString[0] == 's' && colorString[1] == 'c' && colorString[2] == '#')
@@ -111,7 +87,7 @@ public static partial class ColorHelper
                 return Color.FromArgb(255, (byte)(scR * 255), (byte)(scG * 255), (byte)(scB * 255));
             }
 
-            return ThrowFormatException();
+            return ThrowFormatException<Color>();
         }
 
         var prop = typeof(Colors).GetTypeInfo().GetDeclaredProperty(colorString);
@@ -123,10 +99,10 @@ public static partial class ColorHelper
 #pragma warning restore CS8605 // Unboxing a possibly null value.
         }
 
-        return ThrowFormatException();
+        return ThrowFormatException<Color>();
 
         static void ThrowArgumentException() => throw new ArgumentException("The parameter \"colorString\" must not be null or empty.");
-        static Color ThrowFormatException() => throw new FormatException("The parameter \"colorString\" is not a recognized Color format.");
+        static T ThrowFormatException<T>() => throw new FormatException("The parameter \"colorString\" is not a recognized Color format.");
     }
 
     internal static (double h1, double chroma) CalculateHueAndChroma(Color color, out double min, out double max, out double alpha)

--- a/components/Helpers/src/ColorHelper/ColorHelper.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.cs
@@ -24,7 +24,7 @@ public static partial class ColorHelper
     /// </summary>
     /// <param name="colorString">The XAML color string.</param>
     /// <returns>The created <see cref="Color"/>.</returns>
-    public static Color ToColor(this string colorString)
+    public static Color ParseColor(string colorString)
     {
         if (string.IsNullOrEmpty(colorString))
         {
@@ -128,42 +128,6 @@ public static partial class ColorHelper
         static void ThrowArgumentException() => throw new ArgumentException("The parameter \"colorString\" must not be null or empty.");
         static Color ThrowFormatException() => throw new FormatException("The parameter \"colorString\" is not a recognized Color format.");
     }
-
-    /// <summary>
-    /// Converts a <see cref="Color"/> to a hexadecimal string representation.
-    /// </summary>
-    /// <param name="color">The color to convert.</param>
-    /// <returns>The hexadecimal string representation of the color.</returns>
-    public static string ToHex(this Color color)
-    {
-        return $"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}";
-    }
-
-    /// <summary>
-    /// Converts a <see cref="Color"/> to a premultiplied Int32 - 4 byte ARGB structure.
-    /// </summary>
-    /// <param name="color">The color to convert.</param>
-    /// <returns>The int representation of the color.</returns>
-    public static int ToInt(this Color color)
-    {
-        var a = color.A + 1;
-        var col = (color.A << 24) | ((byte)((color.R * a) >> 8) << 16) | ((byte)((color.G * a) >> 8) << 8) | (byte)((color.B * a) >> 8);
-        return col;
-    }
-
-    /// <summary>
-    /// Converts a <see cref="Color"/> to an <see cref="HslColor"/>.
-    /// </summary>
-    /// <param name="color">The <see cref="Color"/> to convert.</param>
-    /// <returns>The converted <see cref="HslColor"/>.</returns>
-    public static HslColor ToHsl(this Color color) => (HslColor)color;
-
-    /// <summary>
-    /// Converts a <see cref="Color"/> to an <see cref="HsvColor"/>.
-    /// </summary>
-    /// <param name="color">The <see cref="Color"/> to convert.</param>
-    /// <returns>The converted <see cref="HsvColor"/>.</returns>
-    public static HsvColor ToHsv(this Color color) => (HsvColor)color;
 
     internal static (double h1, double chroma) CalculateHueAndChroma(Color color, out double min, out double max, out double alpha)
     {

--- a/components/Helpers/src/ColorHelper/ColorHelper.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.cs
@@ -122,7 +122,7 @@ public static partial class ColorHelper
     {
         color = default;
 
-        if (!MatchArgPattern<double>(hslColor, "hsl", out var args))
+        if (!MatchArgPattern(hslColor, "hsl", out var args))
             return false;
 
         if (args.Length != 3)
@@ -142,7 +142,7 @@ public static partial class ColorHelper
     {
         color = default;
 
-        if (!MatchArgPattern<double>(hsvColor, "hsv", out var args))
+        if (!MatchArgPattern(hsvColor, "hsv", out var args))
             return false;
 
         if (args.Length != 3)
@@ -365,8 +365,7 @@ public static partial class ColorHelper
     /// <summary>
     /// Parses a string to match the argument pattern "<paramref name="funcName"/>(args[0], args[1], ...)"
     /// </summary>
-    private static bool MatchArgPattern<T>(string value, string funcName, out T?[] args)
-        where T : IParsable<T>
+    private static bool MatchArgPattern(string value, string funcName, out double[] args)
     {
         args = [];
 
@@ -389,10 +388,10 @@ public static partial class ColorHelper
         var argStrings = value.Split(',');
 
         // Parse the args into an array of doubles
-        args = new T[argStrings.Length];
+        args = new double[argStrings.Length];
         for (var i = 0; i < argStrings.Length; i++)
         {
-            if (!T.TryParse(argStrings[i], null, out args[i]))
+            if (!double.TryParse(argStrings[i], null, out args[i]))
                 return false;
         }
 

--- a/components/Helpers/src/ColorHelper/ColorHelper.cs
+++ b/components/Helpers/src/ColorHelper/ColorHelper.cs
@@ -299,21 +299,21 @@ public static partial class ColorHelper
         throw new FormatException($"The name '{colorName}' not a valid color");
     }
 
-    internal static (double h1, double chroma) CalculateHueAndChroma(Color color, out double min, out double max, out double alpha)
+    internal static (float h1, float chroma) CalculateHueAndChroma(Color color, out float min, out float max, out float alpha)
     {
         // This code is shared between both the conversion
         // to both HSL and HSV from RGB.
 
-        var r = (double)color.R / 255;
-        var g = (double)color.G / 255;
-        var b = (double)color.B / 255;
-        alpha = (double)color.A / 255;
+        var r = (float)color.R / 255;
+        var g = (float)color.G / 255;
+        var b = (float)color.B / 255;
+        alpha = (float)color.A / 255;
 
         max = Math.Max(Math.Max(r, g), b);
         min = Math.Min(Math.Min(r, g), b);
         var chroma = max - min;
 
-        double h1;
+        float h1;
         if (chroma == 0)
         {
             // No max
@@ -338,20 +338,20 @@ public static partial class ColorHelper
         return (h1, chroma);
     }
 
-    internal static Color FromHueChroma(double h1, double chroma, double x, double m, double alpha)
+    internal static Color FromHueChroma(float h1, float chroma, float x, float m, float alpha)
     {
         // This code is shared between both the conversion
         // from both HSL and HSV to RGB.
 
-        double r1, g1, b1;
+        float r1, g1, b1;
         (r1, g1, b1) = h1 switch
         {
-            < 1 => (chroma, x, 0d),
-            < 2 => (x, chroma, 0d),
-            < 3 => (0d, chroma, x),
-            < 4 => (0d, x, chroma),
-            < 5 => (x, 0d, chroma),
-            _ => (chroma, 0d, x),
+            < 1 => (chroma, x, 0f),
+            < 2 => (x, chroma, 0f),
+            < 3 => (0f, chroma, x),
+            < 4 => (0f, x, chroma),
+            < 5 => (x, 0f, chroma),
+            _ => (chroma, 0f, x),
         };
 
         byte r = (byte)(255 * (r1 + m));
@@ -365,7 +365,7 @@ public static partial class ColorHelper
     /// <summary>
     /// Parses a string to match the argument pattern "<paramref name="funcName"/>(args[0], args[1], ...)"
     /// </summary>
-    private static bool MatchArgPattern(string value, string funcName, out double[] args)
+    private static bool MatchArgPattern(string value, string funcName, out float[] args)
     {
         args = [];
 
@@ -388,10 +388,10 @@ public static partial class ColorHelper
         var argStrings = value.Split(',');
 
         // Parse the args into an array of doubles
-        args = new double[argStrings.Length];
+        args = new float[argStrings.Length];
         for (var i = 0; i < argStrings.Length; i++)
         {
-            if (!double.TryParse(argStrings[i], null, out args[i]))
+            if (!float.TryParse(argStrings[i], null, out args[i]))
                 return false;
         }
 

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -18,6 +18,26 @@ public struct HslColor
     private double _alpha;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="HsvColor"/> struct.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to convert to a <see cref="HsvColor"/>.</param>
+    private HslColor(Color color)
+    {
+        // Calculate hue, chroma, and supplementary values
+        (double h1, double chroma) = ColorHelper.CalculateHueAndChroma(color, out var min, out var max, out var alpha);
+        
+        // Calculate saturation and lightness
+        double lightness = 0.5 * (max + min);
+        double saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
+        
+        // Set hsl properties
+        H = 60 * h1;
+        S = saturation;
+        L = lightness;
+        A = alpha;
+    }
+
+    /// <summary>
     /// Creates a new <see cref="HslColor"/>.
     /// </summary>
     /// <param name="hue">The color's hue.</param>
@@ -101,4 +121,9 @@ public struct HslColor
     /// Cast a <see cref="HslColor"/> to a <see cref="Color"/>.
     /// </summary>
     public static implicit operator Color(HslColor hsl) => hsl.ToColor();
+
+    /// <summary>
+    /// Cast a <see cref="Color"/> to <see cref="HslColor"/>
+    /// </summary>
+    public static explicit operator HslColor(Color color) => new(color);
 }

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -15,24 +15,28 @@ public struct HslColor
     /// <summary>
     /// The hue value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Hue property")]
     public double H;
 
     /// <summary>
     /// The saturation value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Saturation property")]
     public double S;
 
     /// <summary>
     /// The lightness value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Lightness property")]
     public double L;
 
     /// <summary>
     /// The alpha/opacity value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Alpha property")]
     public double A;
 

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -117,6 +117,9 @@ public struct HslColor
         return ColorHelper.FromHueChroma(h1, chroma, x, m, A);
     }
 
+    /// <inheritdoc/>
+    public override readonly string ToString() => $"hsl({H:N0}, {S}, {L})";
+
     /// <summary>
     /// Cast a <see cref="HslColor"/> to a <see cref="Color"/>.
     /// </summary>
@@ -126,4 +129,9 @@ public struct HslColor
     /// Cast a <see cref="Color"/> to <see cref="HslColor"/>
     /// </summary>
     public static explicit operator HslColor(Color color) => new(color);
+
+    /// <summary>
+    /// Cast a <see cref="HsvColor"/> to <see cref="HslColor"/>
+    /// </summary>
+    public static explicit operator HslColor(HsvColor color) => new(color);
 }

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -12,10 +12,29 @@ namespace CommunityToolkit.WinUI;
 /// </summary>
 public struct HslColor
 {
-    private double _hue;
-    private double _saturation;
-    private double _lightness;
-    private double _alpha;
+    /// <summary>
+    /// The hue value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Hue property")]
+    public double H;
+
+    /// <summary>
+    /// The saturation value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Saturation property")]
+    public double S;
+
+    /// <summary>
+    /// The lightness value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Lightness property")]
+    public double L;
+
+    /// <summary>
+    /// The alpha/opacity value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Alpha property")]
+    public double A;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HsvColor"/> struct.
@@ -61,10 +80,10 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 360.
     /// </remarks>
-    public double H
+    public double Hue
     {
-        readonly get => _hue;
-        set => _hue = Math.Clamp(value, 0, 360);
+        readonly get => Math.Clamp(H, 0, 360);
+        set => H = Math.Clamp(value, 0, 360);
     }
 
     /// <summary>
@@ -73,10 +92,10 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double S
+    public double Saturation
     {
-        readonly get => _saturation;
-        set => _saturation = Math.Clamp(value, 0, 1);
+        readonly get => Math.Clamp(S, 0, 1);
+        set => S = Math.Clamp(value, 0, 1);
     }
 
     /// <summary>
@@ -85,10 +104,10 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double L
+    public double Lightness
     {
-        readonly get => _lightness;
-        set => _lightness = Math.Clamp(value, 0, 1);
+        readonly get => Math.Clamp(L, 0, 1);
+        set => L = Math.Clamp(value, 0, 1);
     }
 
     /// <summary>
@@ -97,10 +116,10 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double A
+    public double Alpha
     {
-        readonly get => _alpha;
-        set => _alpha = Math.Clamp(value, 0, 1);
+        readonly get => Math.Clamp(A, 0, 1);
+        set => A = Math.Clamp(value, 0, 1);
     }
 
     /// <summary>

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -52,7 +52,7 @@ public struct HslColor
         // Calculate saturation and lightness
         double lightness = 0.5 * (max + min);
         double saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
-        
+
         // Set hsl properties
         Hue = 60 * h1;
         Saturation = saturation;
@@ -71,10 +71,12 @@ public struct HslColor
     public static HslColor Create(double hue, double saturation, double lightness, double alpha = 1)
     {
         HslColor color = default;
-        color.Hue = hue;
-        color.Saturation = saturation;
-        color.Lightness = lightness;
-        color.Alpha = alpha;
+#pragma warning disable 0618
+        color.H = hue;
+        color.S = saturation;
+        color.L = lightness;
+        color.A = alpha;
+#pragma warning restore 0618
         return color;
     }
 

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -5,27 +5,60 @@
 namespace CommunityToolkit.WinUI;
 
 /// <summary>
-/// Defines a color in Hue/Saturation/Lightness (HSL) space.
+/// Defines a color in Hue/Saturation/Lightness (HSL) space with alpha.
 /// </summary>
 public struct HslColor
 {
-    /// <summary>
-    /// The Hue in 0..360 range.
-    /// </summary>
-    public double H;
+    private double _hue;
+    private double _saturation;
+    private double _lightness;
+    private double _alpha;
 
     /// <summary>
-    /// The Saturation in 0..1 range.
+    /// Gets or sets the hue.
     /// </summary>
-    public double S;
+    /// <remarks>
+    /// This value is clamped between 0 and 360.
+    /// </remarks>
+    public double H
+    {
+        readonly get => _hue;
+        set => _hue = Math.Clamp(value, 0, 360);
+    }
 
     /// <summary>
-    /// The Lightness in 0..1 range.
+    /// Gets or sets the saturation.
     /// </summary>
-    public double L;
+    /// <remarks>
+    /// This value is clamped between 0 and 1.
+    /// </remarks>
+    public double S
+    {
+        readonly get => _saturation;
+        set => _saturation = Math.Clamp(value, 0, 1);
+    }
 
     /// <summary>
-    /// The Alpha/opacity in 0..1 range.
+    /// Gets or sets the lightness.
     /// </summary>
-    public double A;
+    /// <remarks>
+    /// This value is clamped between 0 and 1.
+    /// </remarks>
+    public double L
+    {
+        readonly get => _lightness;
+        set => _lightness = Math.Clamp(value, 0, 1);
+    }
+
+    /// <summary>
+    /// Gets or sets the alpha/opacity.
+    /// </summary>
+    /// <remarks>
+    /// This value is clamped between 0 and 1.
+    /// </remarks>
+    public double A
+    {
+        readonly get => _alpha;
+        set => _alpha = Math.Clamp(value, 0, 1);
+    }
 }

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -50,10 +50,10 @@ public struct HslColor
         double saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
         
         // Set hsl properties
-        H = 60 * h1;
-        S = saturation;
-        L = lightness;
-        A = alpha;
+        Hue = 60 * h1;
+        Saturation = saturation;
+        Lightness = lightness;
+        Alpha = alpha;
     }
 
     /// <summary>
@@ -67,12 +67,16 @@ public struct HslColor
     public static HslColor Create(double hue, double saturation, double lightness, double alpha = 1)
     {
         HslColor color = default;
-        color.H = hue;
-        color.S = saturation;
-        color.L = lightness;
-        color.A = alpha;
+        color.Hue = hue;
+        color.Saturation = saturation;
+        color.Lightness = lightness;
+        color.Alpha = alpha;
         return color;
     }
+
+    // This class contains deprecated public backing fields to be removed in a future version.
+    // Suppress the warnings from using them in their new wrapping properties.
+#pragma warning disable 0618
 
     /// <summary>
     /// Gets or sets the hue.
@@ -122,22 +126,24 @@ public struct HslColor
         set => A = Math.Clamp(value, 0, 1);
     }
 
+#pragma warning restore 0618
+
     /// <summary>
     /// Converts the <see cref="HslColor"/> to a <see cref="Color"/>.
     /// </summary>
     /// <returns>The <see cref="HslColor"/> as a <see cref="Color"/>.</returns>
     public readonly Color ToColor()
     {
-        double chroma = (1 - Math.Abs((2 * L) - 1)) * S;
-        double h1 = H / 60;
+        double chroma = (1 - Math.Abs((2 * Lightness) - 1)) * Saturation;
+        double h1 = Hue / 60;
         double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
-        double m = L - (0.5 * chroma);
+        double m = Lightness - (0.5 * chroma);
         
-        return ColorHelper.FromHueChroma(h1, chroma, x, m, A);
+        return ColorHelper.FromHueChroma(h1, chroma, x, m, Alpha);
     }
 
     /// <inheritdoc/>
-    public override readonly string ToString() => $"hsl({H:N0}, {S}, {L})";
+    public override readonly string ToString() => $"hsl({Hue:N0}, {Saturation}, {Lightness})";
 
     /// <summary>
     /// Cast a <see cref="HslColor"/> to a <see cref="Color"/>.

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Windows.UI;
+using ColorHelper = CommunityToolkit.WinUI.Helpers.ColorHelper;
+
 namespace CommunityToolkit.WinUI;
 
 /// <summary>
@@ -13,6 +16,24 @@ public struct HslColor
     private double _saturation;
     private double _lightness;
     private double _alpha;
+
+    /// <summary>
+    /// Creates a new <see cref="HslColor"/>.
+    /// </summary>
+    /// <param name="hue">The color's hue.</param>
+    /// <param name="saturation">The color's saturation.</param>
+    /// <param name="lightness">The color's lightness.</param>
+    /// <param name="alpha">The alpha/opacity.</param>
+    /// <returns>The new <see cref="HslColor"/>.</returns>
+    public static HslColor Create(double hue, double saturation, double lightness, double alpha = 1)
+    {
+        HslColor color = default;
+        color.H = hue;
+        color.S = saturation;
+        color.L = lightness;
+        color.A = alpha;
+        return color;
+    }
 
     /// <summary>
     /// Gets or sets the hue.
@@ -61,4 +82,23 @@ public struct HslColor
         readonly get => _alpha;
         set => _alpha = Math.Clamp(value, 0, 1);
     }
+
+    /// <summary>
+    /// Converts the <see cref="HslColor"/> to a <see cref="Color"/>.
+    /// </summary>
+    /// <returns>The <see cref="HslColor"/> as a <see cref="Color"/>.</returns>
+    public readonly Color ToColor()
+    {
+        double chroma = (1 - Math.Abs((2 * L) - 1)) * S;
+        double h1 = H / 60;
+        double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
+        double m = L - (0.5 * chroma);
+        
+        return ColorHelper.FromHueChroma(h1, chroma, x, m, A);
+    }
+
+    /// <summary>
+    /// Cast a <see cref="HslColor"/> to a <see cref="Color"/>.
+    /// </summary>
+    public static implicit operator Color(HslColor hsl) => hsl.ToColor();
 }

--- a/components/Helpers/src/ColorHelper/HslColor.cs
+++ b/components/Helpers/src/ColorHelper/HslColor.cs
@@ -47,11 +47,11 @@ public struct HslColor
     private HslColor(Color color)
     {
         // Calculate hue, chroma, and supplementary values
-        (double h1, double chroma) = ColorHelper.CalculateHueAndChroma(color, out var min, out var max, out var alpha);
+        (float h1, float chroma) = ColorHelper.CalculateHueAndChroma(color, out var min, out var max, out var alpha);
         
         // Calculate saturation and lightness
-        double lightness = 0.5 * (max + min);
-        double saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
+        float lightness = 0.5f * (max + min);
+        float saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
 
         // Set hsl properties
         Hue = 60 * h1;
@@ -68,7 +68,7 @@ public struct HslColor
     /// <param name="lightness">The color's lightness.</param>
     /// <param name="alpha">The alpha/opacity.</param>
     /// <returns>The new <see cref="HslColor"/>.</returns>
-    public static HslColor Create(double hue, double saturation, double lightness, double alpha = 1)
+    public static HslColor Create(float hue, float saturation, float lightness, double alpha = 1)
     {
         HslColor color = default;
 #pragma warning disable 0618
@@ -90,9 +90,9 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 360.
     /// </remarks>
-    public double Hue
+    public float Hue
     {
-        readonly get => Math.Clamp(H, 0, 360);
+        readonly get => (float)H;
         set => H = Math.Clamp(value, 0, 360);
     }
 
@@ -102,9 +102,9 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double Saturation
+    public float Saturation
     {
-        readonly get => Math.Clamp(S, 0, 1);
+        readonly get => (float)S;
         set => S = Math.Clamp(value, 0, 1);
     }
 
@@ -114,9 +114,9 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double Lightness
+    public float Lightness
     {
-        readonly get => Math.Clamp(L, 0, 1);
+        readonly get => (float)L;
         set => L = Math.Clamp(value, 0, 1);
     }
 
@@ -126,9 +126,9 @@ public struct HslColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double Alpha
+    public float Alpha
     {
-        readonly get => Math.Clamp(A, 0, 1);
+        readonly get => (float)A;
         set => A = Math.Clamp(value, 0, 1);
     }
 
@@ -140,10 +140,10 @@ public struct HslColor
     /// <returns>The <see cref="HslColor"/> as a <see cref="Color"/>.</returns>
     public readonly Color ToColor()
     {
-        double chroma = (1 - Math.Abs((2 * Lightness) - 1)) * Saturation;
-        double h1 = Hue / 60;
-        double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
-        double m = Lightness - (0.5 * chroma);
+        float chroma = (1 - Math.Abs((2 * Lightness) - 1)) * Saturation;
+        float h1 = Hue / 60;
+        float x = chroma * (1 - Math.Abs((h1 % 2) - 1));
+        float m = Lightness - (0.5f * chroma);
         
         return ColorHelper.FromHueChroma(h1, chroma, x, m, Alpha);
     }

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -117,6 +117,9 @@ public struct HsvColor
         return ColorHelper.FromHueChroma(h1, chroma, x, m, A);
     }
 
+    /// <inheritdoc/>
+    public override readonly string ToString() => $"hsv({H:N0}, {S}, {V})";
+
     /// <summary>
     /// Cast a <see cref="HsvColor"/> to a <see cref="Color"/>.
     /// </summary>
@@ -126,4 +129,9 @@ public struct HsvColor
     /// Cast a <see cref="Color"/> to <see cref="HsvColor"/>
     /// </summary>
     public static explicit operator HsvColor(Color color) => new(color);
+
+    /// <summary>
+    /// Cast a <see cref="HslColor"/> to <see cref="HsvColor"/>
+    /// </summary>
+    public static explicit operator HsvColor(HslColor color) => new(color);
 }

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -16,24 +16,28 @@ public struct HsvColor
     /// <summary>
     /// The hue value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Hue property")]
     public double H;
 
     /// <summary>
     /// The saturation value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Saturation property")]
     public double S;
 
     /// <summary>
     /// The "value" value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Value property")]
     public double V;
 
     /// <summary>
     /// The alpha/opacity value.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Alpha property")]
     public double A;
 

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -18,6 +18,26 @@ public struct HsvColor
     private double _alpha;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="HsvColor"/> struct.
+    /// </summary>
+    /// <param name="color">The <see cref="Color"/> to convert to a <see cref="HsvColor"/>.</param>
+    private HsvColor(Color color)
+    {
+        // Calculate hue, chroma, and supplementary values
+        (double h1, double chroma) = ColorHelper.CalculateHueAndChroma(color, out var _, out var max, out var alpha);
+
+        // Calculate saturation and value
+        double saturation = chroma == 0 ? 0 : chroma / max;
+        double value = max;
+
+        // Set hsv properties
+        H = 60 * h1;
+        S = saturation;
+        V = value;
+        A = alpha;
+    }
+
+    /// <summary>
     /// Creates a new <see cref="HsvColor"/>.
     /// </summary>
     /// <param name="hue">The color's hue.</param>
@@ -84,9 +104,9 @@ public struct HsvColor
     }
 
     /// <summary>
-    /// Converts the <see cref="HslColor"/> to a <see cref="Color"/>.
+    /// Converts the <see cref="HsvColor"/> to a <see cref="Color"/>.
     /// </summary>
-    /// <returns>The <see cref="HslColor"/> as a <see cref="Color"/>.</returns>
+    /// <returns>The <see cref="HsvColor"/> as a <see cref="Color"/>.</returns>
     public readonly Color ToColor()
     {
         double chroma = V * S;
@@ -98,7 +118,12 @@ public struct HsvColor
     }
 
     /// <summary>
-    /// Cast a <see cref="HslColor"/> to a <see cref="Color"/>.
+    /// Cast a <see cref="HsvColor"/> to a <see cref="Color"/>.
     /// </summary>
     public static implicit operator Color(HsvColor hsv) => hsv.ToColor();
+
+    /// <summary>
+    /// Cast a <see cref="Color"/> to <see cref="HsvColor"/>
+    /// </summary>
+    public static explicit operator HsvColor(Color color) => new(color);
 }

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -5,27 +5,60 @@
 namespace CommunityToolkit.WinUI;
 
 /// <summary>
-/// Defines a color in Hue/Saturation/Value (HSV) space.
+/// Defines a color in Hue/Saturation/Value (HSV) space with alpha.
 /// </summary>
 public struct HsvColor
 {
+    private double _hue;
+    private double _saturation;
+    private double _value;
+    private double _alpha;
+    
     /// <summary>
-    /// The Hue in 0..360 range.
+    /// Gets or sets the hue.
     /// </summary>
-    public double H;
-
+    /// <remarks>
+    /// This value is clamped between 0 and 360.
+    /// </remarks>
+    public double H
+    {
+        readonly get => _hue;
+        set => _hue = Math.Clamp(value, 0, 360);
+    }
+    
     /// <summary>
-    /// The Saturation in 0..1 range.
+    /// Gets or sets the saturation.
     /// </summary>
-    public double S;
-
+    /// <remarks>
+    /// This value is clamped between 0 and 1.
+    /// </remarks>
+    public double S
+    {
+        readonly get => _saturation;
+        set => _saturation = Math.Clamp(value, 0, 1);
+    }
+    
     /// <summary>
-    /// The Value in 0..1 range.
+    /// Gets or sets the color value.
     /// </summary>
-    public double V;
-
+    /// <remarks>
+    /// This value is clamped between 0 and 1.
+    /// </remarks>
+    public double V
+    {
+        readonly get => _value;
+        set => _value = Math.Clamp(value, 0, 1);
+    }
+    
     /// <summary>
-    /// The Alpha/opacity in 0..1 range.
+    /// Gets or sets the alpha/opacity.
     /// </summary>
-    public double A;
+    /// <remarks>
+    /// This value is clamped between 0 and 1.
+    /// </remarks>
+    public double A
+    {
+        readonly get => _alpha;
+        set => _alpha = Math.Clamp(value, 0, 1);
+    }
 }

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -12,10 +12,29 @@ namespace CommunityToolkit.WinUI;
 /// </summary>
 public struct HsvColor
 {
-    private double _hue;
-    private double _saturation;
-    private double _value;
-    private double _alpha;
+    /// <summary>
+    /// The hue value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Hue property")]
+    public double H;
+
+    /// <summary>
+    /// The saturation value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Saturation property")]
+    public double S;
+
+    /// <summary>
+    /// The "value" value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Value property")]
+    public double V;
+
+    /// <summary>
+    /// The alpha/opacity value.
+    /// </summary>
+    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Alpha property")]
+    public double A;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HsvColor"/> struct.
@@ -61,10 +80,10 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 360.
     /// </remarks>
-    public double H
+    public double Hue
     {
-        readonly get => _hue;
-        set => _hue = Math.Clamp(value, 0, 360);
+        readonly get => Math.Clamp(H, 0, 360);
+        set => H = Math.Clamp(value, 0, 360);
     }
     
     /// <summary>
@@ -73,10 +92,10 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double S
+    public double Saturation
     {
-        readonly get => _saturation;
-        set => _saturation = Math.Clamp(value, 0, 1);
+        readonly get => Math.Clamp(S, 0, 1);
+        set => S = Math.Clamp(value, 0, 1);
     }
     
     /// <summary>
@@ -85,10 +104,10 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double V
+    public double Value
     {
-        readonly get => _value;
-        set => _value = Math.Clamp(value, 0, 1);
+        readonly get => Math.Clamp(V, 0, 1);
+        set => V = Math.Clamp(value, 0, 1);
     }
     
     /// <summary>
@@ -97,10 +116,10 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double A
+    public double Alpha
     {
-        readonly get => _alpha;
-        set => _alpha = Math.Clamp(value, 0, 1);
+        readonly get => Math.Clamp(A, 0, 1);
+        set => A = Math.Clamp(value, 0, 1);
     }
 
     /// <summary>

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -7,7 +7,6 @@ using ColorHelper = CommunityToolkit.WinUI.Helpers.ColorHelper;
 
 namespace CommunityToolkit.WinUI;
 
-
 /// <summary>
 /// Defines a color in Hue/Saturation/Value (HSV) space with alpha.
 /// </summary>

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -7,6 +7,7 @@ using ColorHelper = CommunityToolkit.WinUI.Helpers.ColorHelper;
 
 namespace CommunityToolkit.WinUI;
 
+
 /// <summary>
 /// Defines a color in Hue/Saturation/Value (HSV) space with alpha.
 /// </summary>
@@ -50,10 +51,10 @@ public struct HsvColor
         double value = max;
 
         // Set hsv properties
-        H = 60 * h1;
-        S = saturation;
-        V = value;
-        A = alpha;
+        Hue = 60 * h1;
+        Saturation = saturation;
+        Value = value;
+        Alpha = alpha;
     }
 
     /// <summary>
@@ -67,13 +68,18 @@ public struct HsvColor
     public static HsvColor Create(double hue, double saturation, double value, double alpha = 1)
     {
         HsvColor color = default;
-        color.H = hue;
-        color.S = saturation;
-        color.V = value;
-        color.A = alpha;
+        color.Hue = hue;
+        color.Saturation = saturation;
+        color.Value = value;
+        color.Alpha = alpha;
         return color;
     }
-    
+
+
+    // This class contains deprecated public backing fields to be removed in a future version.
+    // Suppress the warnings from using them in their new wrapping properties.
+#pragma warning disable 0618
+
     /// <summary>
     /// Gets or sets the hue.
     /// </summary>
@@ -122,22 +128,25 @@ public struct HsvColor
         set => A = Math.Clamp(value, 0, 1);
     }
 
+#pragma warning restore 0618
+
+
     /// <summary>
     /// Converts the <see cref="HsvColor"/> to a <see cref="Color"/>.
     /// </summary>
     /// <returns>The <see cref="HsvColor"/> as a <see cref="Color"/>.</returns>
     public readonly Color ToColor()
     {
-        double chroma = V * S;
-        double h1 = H / 60;
+        double chroma = Value * Saturation;
+        double h1 = Hue / 60;
         double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
-        double m = V - chroma;
+        double m = Value - chroma;
 
-        return ColorHelper.FromHueChroma(h1, chroma, x, m, A);
+        return ColorHelper.FromHueChroma(h1, chroma, x, m, Alpha);
     }
 
     /// <inheritdoc/>
-    public override readonly string ToString() => $"hsv({H:N0}, {S}, {V})";
+    public override readonly string ToString() => $"hsv({Hue:N0}, {Saturation}, {Value})";
 
     /// <summary>
     /// Cast a <see cref="HsvColor"/> to a <see cref="Color"/>.

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Windows.UI;
+using ColorHelper = CommunityToolkit.WinUI.Helpers.ColorHelper;
+
 namespace CommunityToolkit.WinUI;
 
 /// <summary>
@@ -13,6 +16,24 @@ public struct HsvColor
     private double _saturation;
     private double _value;
     private double _alpha;
+
+    /// <summary>
+    /// Creates a new <see cref="HsvColor"/>.
+    /// </summary>
+    /// <param name="hue">The color's hue.</param>
+    /// <param name="saturation">The color's saturation.</param>
+    /// <param name="value">The color's value.</param>
+    /// <param name="alpha">The alpha/opacity.</param>
+    /// <returns>The new <see cref="HsvColor"/>.</returns>
+    public static HsvColor Create(double hue, double saturation, double value, double alpha = 1)
+    {
+        HsvColor color = default;
+        color.H = hue;
+        color.S = saturation;
+        color.V = value;
+        color.A = alpha;
+        return color;
+    }
     
     /// <summary>
     /// Gets or sets the hue.
@@ -61,4 +82,23 @@ public struct HsvColor
         readonly get => _alpha;
         set => _alpha = Math.Clamp(value, 0, 1);
     }
+
+    /// <summary>
+    /// Converts the <see cref="HslColor"/> to a <see cref="Color"/>.
+    /// </summary>
+    /// <returns>The <see cref="HslColor"/> as a <see cref="Color"/>.</returns>
+    public readonly Color ToColor()
+    {
+        double chroma = V * S;
+        double h1 = H / 60;
+        double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
+        double m = V - chroma;
+
+        return ColorHelper.FromHueChroma(h1, chroma, x, m, A);
+    }
+
+    /// <summary>
+    /// Cast a <see cref="HslColor"/> to a <see cref="Color"/>.
+    /// </summary>
+    public static implicit operator Color(HsvColor hsv) => hsv.ToColor();
 }

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -71,10 +71,12 @@ public struct HsvColor
     public static HsvColor Create(double hue, double saturation, double value, double alpha = 1)
     {
         HsvColor color = default;
-        color.Hue = hue;
-        color.Saturation = saturation;
-        color.Value = value;
-        color.Alpha = alpha;
+#pragma warning disable 0618
+        color.H = hue;
+        color.S = saturation;
+        color.V = value;
+        color.A = alpha;
+#pragma warning restore 0618
         return color;
     }
 

--- a/components/Helpers/src/ColorHelper/HsvColor.cs
+++ b/components/Helpers/src/ColorHelper/HsvColor.cs
@@ -47,11 +47,11 @@ public struct HsvColor
     private HsvColor(Color color)
     {
         // Calculate hue, chroma, and supplementary values
-        (double h1, double chroma) = ColorHelper.CalculateHueAndChroma(color, out var _, out var max, out var alpha);
+        (float h1, float chroma) = ColorHelper.CalculateHueAndChroma(color, out var _, out var max, out var alpha);
 
         // Calculate saturation and value
-        double saturation = chroma == 0 ? 0 : chroma / max;
-        double value = max;
+        float saturation = chroma == 0 ? 0 : chroma / max;
+        float value = max;
 
         // Set hsv properties
         Hue = 60 * h1;
@@ -68,7 +68,7 @@ public struct HsvColor
     /// <param name="value">The color's value.</param>
     /// <param name="alpha">The alpha/opacity.</param>
     /// <returns>The new <see cref="HsvColor"/>.</returns>
-    public static HsvColor Create(double hue, double saturation, double value, double alpha = 1)
+    public static HsvColor Create(float hue, float saturation, float value, float alpha = 1)
     {
         HsvColor color = default;
 #pragma warning disable 0618
@@ -80,7 +80,6 @@ public struct HsvColor
         return color;
     }
 
-
     // This class contains deprecated public backing fields to be removed in a future version.
     // Suppress the warnings from using them in their new wrapping properties.
 #pragma warning disable 0618
@@ -91,9 +90,9 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 360.
     /// </remarks>
-    public double Hue
+    public float Hue
     {
-        readonly get => Math.Clamp(H, 0, 360);
+        readonly get => (float)H;
         set => H = Math.Clamp(value, 0, 360);
     }
     
@@ -103,9 +102,9 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double Saturation
+    public float Saturation
     {
-        readonly get => Math.Clamp(S, 0, 1);
+        readonly get => (float)S;
         set => S = Math.Clamp(value, 0, 1);
     }
     
@@ -115,9 +114,9 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double Value
+    public float Value
     {
-        readonly get => Math.Clamp(V, 0, 1);
+        readonly get => (float)V;
         set => V = Math.Clamp(value, 0, 1);
     }
     
@@ -127,9 +126,9 @@ public struct HsvColor
     /// <remarks>
     /// This value is clamped between 0 and 1.
     /// </remarks>
-    public double Alpha
+    public float Alpha
     {
-        readonly get => Math.Clamp(A, 0, 1);
+        readonly get => (float)A;
         set => A = Math.Clamp(value, 0, 1);
     }
 
@@ -142,10 +141,10 @@ public struct HsvColor
     /// <returns>The <see cref="HsvColor"/> as a <see cref="Color"/>.</returns>
     public readonly Color ToColor()
     {
-        double chroma = Value * Saturation;
-        double h1 = Hue / 60;
-        double x = chroma * (1 - Math.Abs((h1 % 2) - 1));
-        double m = Value - chroma;
+        float chroma = Value * Saturation;
+        float h1 = Hue / 60;
+        float x = chroma * (1 - Math.Abs((h1 % 2) - 1));
+        float m = Value - chroma;
 
         return ColorHelper.FromHueChroma(h1, chroma, x, m, Alpha);
     }

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.WinUI.Helpers;
+using ColorHelper = CommunityToolkit.WinUI.Helpers.ColorHelper;
 
 namespace HelpersTests;
 
@@ -13,49 +14,49 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_ToColor_Predifined()
     {
-        Assert.AreEqual("Red".ToColor(), Colors.Red);
+        Assert.AreEqual(ColorHelper.ParseColor("Red"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_ToColor_Hex8Digits()
     {
-        Assert.AreEqual("#FFFF0000".ToColor(), Colors.Red);
+        Assert.AreEqual(ColorHelper.ParseColor("#FFFF0000"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_ToColor_Hex6Digits()
     {
-        Assert.AreEqual("#FF0000".ToColor(), Colors.Red);
+        Assert.AreEqual(ColorHelper.ParseColor("#FF0000"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_ToColor_Hex4Digits()
     {
-        Assert.AreEqual("#FF00".ToColor(), Colors.Red);
+        Assert.AreEqual(ColorHelper.ParseColor("#FF00"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_ToColor_Hex3Digits()
     {
-        Assert.AreEqual("#F00".ToColor(), Colors.Red);
+        Assert.AreEqual(ColorHelper.ParseColor("#F00"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_ToColor_ScreenColor()
     {
-        Assert.AreEqual("sc#1.0,1.0,0,0".ToColor(), Colors.Red);
+        Assert.AreEqual(ColorHelper.ParseColor("sc#1.0,1.0,0,0"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_ToHex()
     {
-        Assert.AreEqual(Colors.Red.ToHex(), "#FFFF0000");
+        Assert.AreEqual(Colors.Red.ToString(), "#FFFF0000");
     }
 
     [TestCategory("Helpers")]
@@ -128,11 +129,13 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_ToHsv()
     {
-        HsvColor hsvColor = default;
-        hsvColor.A = 1.0;   // Alpha
-        hsvColor.H = 100;   // Hue
-        hsvColor.S = 0.25;  // Saturation
-        hsvColor.V = 0.80;  // Value
+        HsvColor hsvColor = new HsvColor
+        {
+            A = 1.0,        // Alpha
+            H = 100,        // Hue
+            S = 0.25,       // Saturation
+            V = 0.80,       // Value
+        };
 
         // Use a test color with non-zero/non-max values for both RGB and HSV
         var color = Windows.UI.Color.FromArgb(255, 170, 204, 153).ToHsv();
@@ -150,11 +153,13 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_ToHsv_MaxR()
     {
-        HsvColor hsvColor = default;
-        hsvColor.A = 1.0;        // Alpha
-        hsvColor.H = 330;        // Hue
-        hsvColor.S = 0.58823529; // Saturation
-        hsvColor.V = 1;          // Value
+        HsvColor hsvColor = new HsvColor
+        {
+            A = 1.0,        // Alpha
+            H = 330,        // Hue
+            S = 0.58823529, // Saturation
+            V = 1,          // Value
+        };
 
         // Use a test color with non-zero/non-max values for both RGB and HSV
         var color = Windows.UI.Color.FromArgb(255, 255, 105, 180).ToHsv();
@@ -172,13 +177,13 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_FromHsl()
     {
-        Assert.AreEqual(CommunityToolkit.WinUI.Helpers.ColorHelper.FromHsl(0.0, 1.0, 0.5), Colors.Red);
+        Assert.AreEqual(HslColor.Create(0.0, 1.0, 0.5), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_FromHsv()
     {
-        Assert.AreEqual(CommunityToolkit.WinUI.Helpers.ColorHelper.FromHsv(0.0, 1.0, 1.0), Colors.Red);
+        Assert.AreEqual(HsvColor.Create(0.0, 1.0, 1.0), Colors.Red);
     }
 }

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -69,7 +69,7 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_ToHsl()
     {
-        HslColor hslRed;
+        HslColor hslRed = default;
         hslRed.A = 1.0;  // Alpha
         hslRed.H = 0.0;  // Hue
         hslRed.S = 1.0;  // Saturation
@@ -82,7 +82,7 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_ToHsl_White()
     {
-        HslColor hslWhite;
+        HslColor hslWhite = default;
         hslWhite.A = 1.0;  // Alpha
         hslWhite.H = 0.0;  // Hue
         hslWhite.S = 0.0;  // Saturation
@@ -96,7 +96,7 @@ public class Test_ColorHelper
     public void Test_ColorHelper_ToHsl_MaxR()
     {
         // Test when given an RGB value where R is the max value.
-        HslColor hslColor;
+        HslColor hslColor = default;
         hslColor.A = 1.0;        // Alpha
         hslColor.H = 330.0;      // Hue
         hslColor.S = 1.0;        // Saturation
@@ -114,7 +114,7 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_ToHsv()
     {
-        HsvColor hsvColor;
+        HsvColor hsvColor = default;
         hsvColor.A = 1.0;   // Alpha
         hsvColor.H = 100;   // Hue
         hsvColor.S = 0.25;  // Saturation
@@ -136,7 +136,7 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_ToHsv_MaxR()
     {
-        HsvColor hsvColor;
+        HsvColor hsvColor = default;
         hsvColor.A = 1.0;        // Alpha
         hsvColor.H = 330;        // Hue
         hsvColor.S = 0.58823529; // Saturation

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -60,6 +60,20 @@ public class Test_ColorHelper
 
     [TestCategory("Helpers")]
     [TestMethod]
+    public void Test_ColorHelper_HslToString()
+    {
+        Assert.AreEqual(((HslColor)Colors.Red).ToString(), "hsl(0, 1, 0.5)");
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_HsvToString()
+    {
+        Assert.AreEqual(((HsvColor)Colors.Red).ToString(), "hsv(0, 1, 1)");
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
     public void Test_ColorHelper_ToInt()
     {
         Assert.AreEqual(Colors.Red.ToInt(), -65536);

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -54,6 +54,20 @@ public class Test_ColorHelper
 
     [TestCategory("Helpers")]
     [TestMethod]
+    public void Test_ColorHelper_ParseHslColor()
+    {
+        Assert.AreEqual(ColorHelper.ParseHslColor("hsl(0,1,0.5)"), Colors.Red);
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_ParseHsvColor()
+    {
+        Assert.AreEqual(ColorHelper.ParseHsvColor("hsv(0,1,1)"), Colors.Red);
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
     public void Test_ColorHelper_ToHex()
     {
         Assert.AreEqual(Colors.Red.ToString(), "#FFFF0000");

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -215,13 +215,6 @@ public class Test_ColorHelper
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_Mix()
-    {
-        Assert.AreEqual(Color.Mix(Colors.White, Colors.Black, 0.6625), Colors.DarkGray);
-    }
-
-    [TestCategory("Helpers")]
-    [TestMethod]
     public void Test_ColorHelper_WithHue()
     {
         Assert.AreEqual(Colors.Blue.WithHue(0), Colors.Red);
@@ -249,6 +242,13 @@ public class Test_ColorHelper
     }
 
 #if NET10_0_OR_GREATER
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_Mix()
+    {
+        Assert.AreEqual(Color.Mix(Colors.White, Colors.Black, 0.6625), Colors.DarkGray);
+    }
 
     [TestCategory("Helpers")]
     [TestMethod]

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -12,42 +12,42 @@ public class Test_ColorHelper
 {
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_ToColor_Predifined()
+    public void Test_ColorHelper_ParseColor_Predifined()
     {
         Assert.AreEqual(ColorHelper.ParseColor("Red"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_ToColor_Hex8Digits()
+    public void Test_ColorHelper_ParseColor_Hex8Digits()
     {
         Assert.AreEqual(ColorHelper.ParseColor("#FFFF0000"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_ToColor_Hex6Digits()
+    public void Test_ColorHelper_ParseColor_Hex6Digits()
     {
         Assert.AreEqual(ColorHelper.ParseColor("#FF0000"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_ToColor_Hex4Digits()
+    public void Test_ColorHelper_ParseColor_Hex4Digits()
     {
         Assert.AreEqual(ColorHelper.ParseColor("#FF00"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_ToColor_Hex3Digits()
+    public void Test_ColorHelper_ParseColor_Hex3Digits()
     {
         Assert.AreEqual(ColorHelper.ParseColor("#F00"), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_ToColor_ScreenColor()
+    public void Test_ColorHelper_ParseColor_ScreenColor()
     {
         Assert.AreEqual(ColorHelper.ParseColor("sc#1.0,1.0,0,0"), Colors.Red);
     }
@@ -175,14 +175,14 @@ public class Test_ColorHelper
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_FromHsl()
+    public void Test_ColorHelper_CreateHsl()
     {
         Assert.AreEqual(HslColor.Create(0.0, 1.0, 0.5), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
-    public void Test_ColorHelper_FromHsv()
+    public void Test_ColorHelper_CreateHsv()
     {
         Assert.AreEqual(HsvColor.Create(0.0, 1.0, 1.0), Colors.Red);
     }

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.WinUI.Helpers;
+using Windows.UI;
 using ColorHelper = CommunityToolkit.WinUI.Helpers.ColorHelper;
 
 namespace HelpersTests;
@@ -200,4 +201,66 @@ public class Test_ColorHelper
     {
         Assert.AreEqual(HsvColor.Create(0.0, 1.0, 1.0), Colors.Red);
     }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_AlphaOver()
+    {
+        Assert.AreEqual(Colors.Red.AlphaOver(Colors.Blue, 0.5), Color.FromArgb(255, 128, 0, 128));
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_Mix()
+    {
+        Assert.AreEqual(Color.Mix(Colors.White, Colors.Black, 0.6625), Colors.DarkGray);
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_WithHue()
+    {
+        Assert.AreEqual(Colors.Blue.WithHue(0), Colors.Red);
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_WithSaturation()
+    {
+        Assert.AreEqual(Colors.Red.WithSaturation(0), Colors.White);
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_WithValue()
+    {
+        Assert.AreEqual(Colors.Red.WithValue(0), Colors.Black);
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_WithLightness()
+    {
+        Assert.AreEqual(Colors.Red.WithLightness(0), Colors.Black);
+    }
+
+#if NET10_0_OR_GREATER
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_Add()
+    {
+        Assert.AreEqual(Color.Add(Colors.Red, Colors.Blue), Colors.Magenta);
+        Assert.AreEqual(Colors.Red + Colors.Blue, Colors.Magenta);
+    }
+
+    [TestCategory("Helpers")]
+    [TestMethod]
+    public void Test_ColorHelper_Subtract()
+    {
+        Assert.AreEqual(Color.Subtract(Colors.Magenta, Colors.Red), Colors.Blue);
+        Assert.AreEqual(Colors.Magenta - Colors.Red, Colors.Blue);
+    }
+
+#endif
 }

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -11,6 +11,10 @@ namespace HelpersTests;
 [TestClass]
 public class Test_ColorHelper
 {
+    // Keep testing the old APIs until they are removed
+    // In the meantime suppress the warnings from using them
+#pragma warning disable 0618
+
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_ParseColor_Predifined()
@@ -263,4 +267,5 @@ public class Test_ColorHelper
     }
 
 #endif
+#pragma warning restore 0618
 }

--- a/components/Helpers/tests/Test_ColorHelper.cs
+++ b/components/Helpers/tests/Test_ColorHelper.cs
@@ -196,14 +196,14 @@ public class Test_ColorHelper
     [TestMethod]
     public void Test_ColorHelper_CreateHsl()
     {
-        Assert.AreEqual(HslColor.Create(0.0, 1.0, 0.5), Colors.Red);
+        Assert.AreEqual(HslColor.Create(0.0f, 1.0f, 0.5f), Colors.Red);
     }
 
     [TestCategory("Helpers")]
     [TestMethod]
     public void Test_ColorHelper_CreateHsv()
     {
-        Assert.AreEqual(HsvColor.Create(0.0, 1.0, 1.0), Colors.Red);
+        Assert.AreEqual(HsvColor.Create(0.0f, 1.0f, 1.0f), Colors.Red);
     }
 
     [TestCategory("Helpers")]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.101",
+    "version": "10.0.101",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "version": "10.0.101",
     "rollForward": "latestFeature"
   },
-  "msbuild-sdks": 
+  "msbuild-sdks":
   {
     "MSBuild.Sdk.Extras":"3.0.23"
   }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes https://github.com/CommunityToolkit/Labs-Windows/issues/756

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

This PR introduces a new API for the `ColorHelper`, though leaves the old API available with no breaking changes (though marked as deprecated)

## What is the current behavior?

This is the current API
```cs
public static class ColorHelper
{
  public static Color ToColor(this string colorString);
  
  public static string ToHex(this Color color);

  public static int ToInt(this Color color);

  public static HslColor ToHsl(this Color color);

  public static HsvColor ToHsv(this Color color);

  public static Color FromHsl(double hue, double saturation, double lightness, double alpha = 1.0);

  public static Color FromHsv(double hue, double saturation, double value, double alpha = 1.0);
}

public struct HslColor
{
  public double H;
  public double S;
  public double L;
  public double A;
}

public struct HsvColor
{
  public double H;
  public double S;
  public double V;
  public double A;
}
```

## What is the new behavior?

This is the full new API, including the old API marked obsolete.

```cs
public static partial class ColorHelper
{
    public static bool TryParseColor(string colorString, out Color color);

    public static bool TryParseHexColor(string hexString, out Color color);

    public static bool TryParseHslColor(string hslColor, out HslColor color);

    public static bool TryParseHsvColor(string hsvColor, out HsvColor color);

    public static bool TryParseScreenColor(string screenColor, out Color color);

    public static bool TryParseColorName(string colorName, out Color color);

    public static Color ParseColor(string colorString);

    public static Color ParseHexColor(string hexColor);

    public static HslColor ParseHslColor(string hslColor);

    public static HsvColor ParseHsvColor(string hsvColor);

    public static Color ParseScreenColor(string screenColor);

    public static Color ParseColorName(string colorName);

    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with ColorHelper.ParseColor(string colorString).")]
    public static Color ToColor(this string colorString);

    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with (Color)HslColor.Create().")]
    public static Color FromHsl(double hue, double saturation, double lightness, double alpha = 1.0);

    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with (Color)HsvColor.Create().")]
    public static Color FromHsv(double hue, double saturation, double value, double alpha = 1.0);

    [Obsolete("This method is marked deprecated, and will be removed in a future version. Please replace with .ToString().")]
    public static string ToHex(this Color color);
}

public static class ColorExtensions
{
    public static int ToInt(this Color color);

    public static HslColor ToHsl(this Color color);

    public static HsvColor ToHsv(this Color color);

    public static Color AlphaOver(this Color @base, Color overlay);

    public static Color AlphaOver(this Color @base, Color overlay, double alpha);

    public static HsvColor WithHue(this Color original, double hue);

    public static HsvColor WithSaturation(this Color original, double saturation);

    public static HsvColor WithValue(this Color original, double value);

    public static HslColor WithLightness(this Color original, double lightness);

#if NET10_0_OR_GREATER
    extension(Color color)
    {
        public static HslColor FromAhsl(float a, float h, float s, float l);

        public static HsvColor FromAhsv(float a, float h, float s, float v);

        public static Color Mix(Color color1, Color color2, double factor);

        public static Color Add(Color color1, Color color2);

        public static Color Subtract(Color color1, Color color2);

        public static Color operator +(Color color1, Color color2);

        public static Color operator -(Color color1, Color color2);
    }
#endif
}

public struct HslColor
{
    public static HslColor Create(float hue, float saturation, float lightness, float alpha = 1);

    public float Hue { readonly get; set; }

    public float Saturation { readonly get; set; }

    public float Lightness { readonly get; set; }

    public float Alpha { readonly get; set; }

    public readonly Color ToColor();

    public static implicit operator Color(HslColor hsl);

    public static explicit operator HslColor(Color color);

    public static explicit operator HslColor(HsvColor color);

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Hue property")]
    public double H;

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Saturation property")]
    public double S;

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Lightness property")]
    public double L;

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Alpha property")]
    public double A;
}

public struct HsvColor
{
    public static HsvColor Create(double hue, double saturation, double value, double alpha = 1);

    public float Hue { readonly get; set; }

    public float Saturation { readonly get; set; }

    public float Value { readonly get; set; }

    public float Alpha { readonly get; set; }

    public readonly Color ToColor();

    public static implicit operator Color(HsvColor hsv);

    public static explicit operator HsvColor(Color color);

    public static explicit operator HsvColor(HslColor color);

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Hue property")]
    public double H;

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Saturation property")]
    public double S;

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Value property")]
    public double V;

    [Obsolete("This field is marked deprecated, and will be removed in a future version. Please replace with the HsvColor.Alpha property")]
    public double A;
}
```

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [x] Tests for the changes have been added (if applicable)
- [x] Header has been added to all new source files
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

By keeping the old fields available and using the new properties to wrap them, breaking changes have been averted. However, the plan would be to removed these deprecated APIs in future versions.

## Other information

Note that the `ObsoleteAttribute` messages contain a recommendation for how to migrate to the new API. All these migrations have complete behavioral parity, except the fields/properties in `HslColor` and `HsvColor` which are now clamped to a valid range.