### PR TITLE
Fixes: Regression in ColorPicker ColorPalette

### DIFF
--- a/components/ColorPicker/src/ColorPicker.cs
+++ b/components/ColorPicker/src/ColorPicker.cs
@@ -766,7 +766,7 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
 
             if (this.PaletteItemGridView != null)
             {
-                this.PaletteItemGridView.SelectedItem = (this.CustomPaletteColors?.Contains(rgbColor) ?? false) ? rgbColor : null;
+                this.PaletteItemGridView.SelectedItem = (this.CustomPaletteColors?.Contains(rgbColor) ?? false) ? (object)rgbColor : null;
             }
 
             if (eventsDisconnectedByMethod)

--- a/components/ColorPicker/src/ColorPicker.cs
+++ b/components/ColorPicker/src/ColorPicker.cs
@@ -764,6 +764,11 @@ public partial class ColorPicker : Microsoft.UI.Xaml.Controls.ColorPicker
                 }
             }
 
+            if (this.PaletteItemGridView != null)
+            {
+                this.PaletteItemGridView.SelectedItem = (this.CustomPaletteColors?.Contains(rgbColor) ?? false) ? rgbColor : null;
+            }
+
             if (eventsDisconnectedByMethod)
             {
                 this.ConnectEvents(true);

--- a/components/ColorPicker/tests/ColorPicker.Tests.projitems
+++ b/components/ColorPicker/tests/ColorPicker.Tests.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExampleColorPickerTestPage.xaml.cs">
       <DependentUpon>ExampleColorPickerTestPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)PaletteSelectionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)ExampleColorPickerTestPage.xaml">

--- a/components/ColorPicker/tests/PaletteSelectionTests.cs
+++ b/components/ColorPicker/tests/PaletteSelectionTests.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Tooling.TestGen;
+using CommunityToolkit.Tests;
+using CommunityToolkit.WinUI.Controls;
+using Microsoft.UI.Xaml.Controls;
+using ColorPicker = CommunityToolkit.WinUI.Controls.ColorPicker;
+
+namespace ColorPickerTests;
+
+[TestClass]
+public partial class PaletteSelectionTests : VisualUITestBase
+{
+    // First color in FluentColorPalette (#ffb900)
+    private static readonly Windows.UI.Color PaletteColor = Windows.UI.Color.FromArgb(255, 255, 185, 0);
+
+    // Second palette color for the round-trip check (#d13438)
+    private static readonly Windows.UI.Color PaletteColor2 = Windows.UI.Color.FromArgb(255, 209, 52, 56);
+
+    // White is not in the FluentColorPalette
+    private static readonly Windows.UI.Color NonPaletteColor = Colors.White;
+
+    /// <summary>
+    /// Verifies that the palette GridView selection follows the Color property when it is changed
+    /// programmatically (e.g. via the spectrum or sliders). Regression test for issue #833.
+    /// </summary>
+    [UIThreadTestMethod]
+    public async Task PaletteGridView_FollowsColorProperty()
+    {
+        var colorPicker = new ColorPicker();
+        await LoadTestContentAsync(colorPicker);
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        // The PaletteItemGridView lives inside a SwitchPresenter Case that is only added to
+        // the visual tree once the palette tab is selected. Navigate there first.
+        var panelSelector = colorPicker.FindDescendant<Segmented>();
+        Assert.IsNotNull(panelSelector, "Could not find ColorPanelSelector in visual tree.");
+
+        var paletteItem = panelSelector.FindDescendant("PaletteItem") as SegmentedItem;
+        Assert.IsNotNull(paletteItem, "Could not find PaletteItem in ColorPanelSelector.");
+
+        panelSelector.SelectedItem = paletteItem;
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        var paletteGridView = colorPicker.FindDescendant("PaletteItemGridView") as GridView;
+        Assert.IsNotNull(paletteGridView, "Could not find PaletteItemGridView in visual tree.");
+
+        // Set to a color that is in the default palette — selection should follow.
+        colorPicker.Color = PaletteColor;
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        Assert.AreEqual(PaletteColor, paletteGridView.SelectedItem,
+            "PaletteItemGridView should select the matching palette color when Color is set.");
+
+        // Set to a color not in the palette — selection should be cleared.
+        colorPicker.Color = NonPaletteColor;
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        Assert.IsNull(paletteGridView.SelectedItem,
+            "PaletteItemGridView should have no selection when Color is not in the palette.");
+
+        // Set to a different palette color — selection should update to match.
+        colorPicker.Color = PaletteColor2;
+        await CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() => { });
+
+        Assert.AreEqual(PaletteColor2, paletteGridView.SelectedItem,
+            "PaletteItemGridView should update its selection when Color changes to another palette color.");
+
+        await UnloadTestContentAsync(colorPicker);
+    }
+}


### PR DESCRIPTION
## Fixes

Fixes #833

Fixes regession, where PaletteItemGridView would not be updated when the selected color changed.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

Bugfix
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

See issue, the selection state of the GridView does not stay synchronized with the other color picker components.

## What is the new behavior?

This restores the spirit of the previous TwoWay data binding between the SelectedValue of the GridView and the selected color.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs (I tested the Wasdk and Wasm sample projects and created an automated test, not sure how and if I should test anything else)
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (if applicable)
- [x] Header has been added to all new source files
- [x] Contains **NO** breaking changes (Previous behavior was clearly broken, so I would not consider it breaking in any way)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

I tested this with the "ColorPicker.Wasdk" and "ColorPicker.Wasm" sample app manually, both previously repro'd the bug and every thing works well with this fix included.

I also create a test case for this issue in the automated tests for colorpicker. 