### PR TITLE
Update Microsoft.WindowsAppSDK to 1.8 stable

### DIFF
--- a/components/Behaviors/src/Dependencies.props
+++ b/components/Behaviors/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0"/>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.1"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
@@ -21,7 +21,7 @@
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.1" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->

--- a/components/ImageCropper/src/Dependencies.props
+++ b/components/ImageCropper/src/Dependencies.props
@@ -21,7 +21,7 @@
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-        <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1"/>
+        <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.4.0"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->

--- a/components/Media/src/Dependencies.props
+++ b/components/Media/src/Dependencies.props
@@ -20,6 +20,6 @@
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/components/SettingsControls/samples/Dependencies.props
+++ b/components/SettingsControls/samples/Dependencies.props
@@ -15,7 +15,7 @@
   
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
-        <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.0"/>
+        <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.1"/>
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
@@ -25,7 +25,7 @@
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">      
-         <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0"/>
+         <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.1"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->


### PR DESCRIPTION
This PR upgrades our tooling, components, and dependencies to the 1.8 version of the Windows App SDK. 

The changes here have had basic builds/tests run locally, and fixes several of the build issues encountered while trying to build WASDK under the new version. 

Remaining uncertainty:
- The errors in the tooling CI are caused by a package reference to an old version of the toolkit using older versions of WADSK, particularly we noted CommunityToolkit.Common (and will check for more). 

Prerequisites:
- The PR at https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/293 needs to be merged before this PR can be closed. 
- Before we can close this PR, we'll need to use the PR nuget feed here to ship a prerelease update to any toolkit components that are referenced in the gallery by our tooling.
    - This is a recurring requirement any time we update the toolkit's dependencies, it also happened with our upgrade to 1.6. 
    - Generally, this friction is being recorded for possible improvements via proper toolkit-using-toolkit tooling.

