### PR TITLE
Upgrade to .NET 10, runner images to windows-2025, use only 26100 Windows SDK

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -78,6 +78,11 @@ body:
        - label: Windows 10 21H2 (Build 19044)
        - label: Windows 10 22H2 (Build 19045)
        - label: Windows 11 21H2 (Build 22000)
+       - label: Windows 11 22H2 (Build 22621)
+       - label: Windows 11 23H2 (Build 22631)
+       - label: Windows 11 24H2 (Build 26100)
+       - label: Windows 11 25H2 (Build 26200)
+       - label: Windows 11 26H1 (Build 28000)
        - label: Other (specify)
 - type: input
   id: environment-windows-build-other-build-number
@@ -96,6 +101,9 @@ body:
        - label: Windows 10, version 2004 (Build 19041)
        - label: Windows 10, version 2104 (Build 20348)
        - label: Windows 11, version 22H2 (Build 22000)
+       - label: Windows 11, version 24H2 (Build 26100)
+       - label: Windows 11, version 25H2 (Build 26200)
+       - label: Windows 11, version 26H1 (Build 28000)
        - label: Other (specify)
 - type: input
   id: environment-app-min-target-other-build-number
@@ -110,7 +118,8 @@ body:
      description: Check one or more of the following options
      options:
        - 2022
-       - Preview
+       - 2026
+       - Insiders
 - type: input
   id: visual-studio-exact-build
   attributes:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
   # Build both Uno.UI/WinUI2/UWP and Uno.WinUI/WinUI3/WindowsAppSDK versions of our packages using a matrix
   build:
     needs: [Xaml-Style-Check]
-    runs-on: windows-2025-large
+    runs-on: windows-latest-large
 
     env:
       PROCDUMP_PATH: ${{ github.workspace }}
@@ -222,7 +222,7 @@ jobs:
           dotnet-dump analyze ${{ steps.detect-dump.outputs.DUMP_FILE }} -c "clrstack" -c "pe -lines" -c "exit"
 
   package:
-    runs-on: windows-2025-large
+    runs-on: windows-latest-large
     needs: [build]
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
@@ -334,7 +334,7 @@ jobs:
   sign:
     needs: [package]
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/') }}
-    runs-on: windows-2025-large
+    runs-on: windows-latest-large
     permissions:
       id-token: write # Required for requesting the JWT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   # This workflow contains a single job called "Xaml-Style-Check"
   Xaml-Style-Check:
-    runs-on: windows-2025-large
+    runs-on: windows-2025
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   # This workflow contains a single job called "Xaml-Style-Check"
   Xaml-Style-Check:
-    runs-on: windows-2025
+    runs-on: windows-2025-large
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -57,7 +57,7 @@ jobs:
   # Build both Uno.UI/WinUI2/UWP and Uno.WinUI/WinUI3/WindowsAppSDK versions of our packages using a matrix
   build:
     needs: [Xaml-Style-Check]
-    runs-on: windows-2025
+    runs-on: windows-2025-large
 
     env:
       PROCDUMP_PATH: ${{ github.workspace }}
@@ -222,7 +222,7 @@ jobs:
           dotnet-dump analyze ${{ steps.detect-dump.outputs.DUMP_FILE }} -c "clrstack" -c "pe -lines" -c "exit"
 
   package:
-    runs-on: windows-2025
+    runs-on: windows-2025-large
     needs: [build]
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
@@ -334,7 +334,7 @@ jobs:
   sign:
     needs: [package]
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/') }}
-    runs-on: windows-2025
+    runs-on: windows-2025-large
     permissions:
       id-token: write # Required for requesting the JWT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   # This workflow contains a single job called "Xaml-Style-Check"
   Xaml-Style-Check:
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -124,6 +124,10 @@ jobs:
           --skip vswinworkloads
           --skip vswin
           --verbose
+
+      - name: Install Windows SDKs
+        shell: pwsh
+        run: ./tooling/Install-WindowsSdk.ps1
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
   # Build both Uno.UI/WinUI2/UWP and Uno.WinUI/WinUI3/WindowsAppSDK versions of our packages using a matrix
   build:
     needs: [Xaml-Style-Check]
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     env:
       PROCDUMP_PATH: ${{ github.workspace }}
@@ -222,7 +222,7 @@ jobs:
           dotnet-dump analyze ${{ steps.detect-dump.outputs.DUMP_FILE }} -c "clrstack" -c "pe -lines" -c "exit"
 
   package:
-    runs-on: windows-2022
+    runs-on: windows-2025
     needs: [build]
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
@@ -334,7 +334,7 @@ jobs:
   sign:
     needs: [package]
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/') }}
-    runs-on: windows-2022
+    runs-on: windows-2025
     permissions:
       id-token: write # Required for requesting the JWT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
   # Build both Uno.UI/WinUI2/UWP and Uno.WinUI/WinUI3/WindowsAppSDK versions of our packages using a matrix
   build:
     needs: [Xaml-Style-Check]
-    runs-on: windows-latest-large
+    runs-on: windows-2025-large
 
     env:
       PROCDUMP_PATH: ${{ github.workspace }}
@@ -222,7 +222,7 @@ jobs:
           dotnet-dump analyze ${{ steps.detect-dump.outputs.DUMP_FILE }} -c "clrstack" -c "pe -lines" -c "exit"
 
   package:
-    runs-on: windows-latest-large
+    runs-on: windows-2025-large
     needs: [build]
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
@@ -334,7 +334,7 @@ jobs:
   sign:
     needs: [package]
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/') }}
-    runs-on: windows-latest-large
+    runs-on: windows-2025-large
     permissions:
       id-token: write # Required for requesting the JWT
 

--- a/components/Segmented/src/Segmented/Segmented.cs
+++ b/components/Segmented/src/Segmented/Segmented.cs
@@ -22,7 +22,6 @@ public partial class Segmented : ListViewBase
         this.DefaultStyleKey = typeof(Segmented);
 
         RegisterPropertyChangedCallback(SelectedIndexProperty, OnSelectedIndexChanged);
-        RegisterPropertyChangedCallback(OrientationProperty, OnSelectedIndexChanged);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Background

During the [.NET 10 SDK upgrade work](https://github.com/CommunityToolkit/Labs-Windows/pull/791), CI started requiring the Visual Studio 2026 / MSBuild 18 toolchain.

[Visual Studio 2026 18.0](https://learn.microsoft.com/visualstudio/releases/2026/release-notes#november-update-1800) is the release that added .NET 10 support, but the [`windows-2022` runner image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) only includes Visual Studio 2022 / MSBuild 17.

That showed up in the .NET 10 upgrade CI runs when [`microsoft/setup-msbuild` wasn't able to resolve MSBuild 18](https://github.com/CommunityToolkit/Labs-Windows/blob/e37ec617585872a00dcca554f5f517bfc277762d/.github/workflows/build.yml#L178-L182) on [`windows-2022`](https://github.com/CommunityToolkit/Labs-Windows/blob/e37ec617585872a00dcca554f5f517bfc277762d/.github/workflows/build.yml#L68), alongside the parallel tooling work in [Tooling #309](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/309).

During the follow-up runner investigation, we confirmed why the workflows had been pinned to `windows-2022` in the first place. GitHub changed [`windows-latest` to resolve to `windows-2025`](https://github.com/CommunityToolkit/Windows/pull/737) on September 30, 2025, and the Windows Server 2025 hosted image no longer included the older Windows SDKs our builds depended on. That broke CI at the time, so the repos were pinned back to `windows-2022` in [Windows #737](https://github.com/CommunityToolkit/Windows/pull/737), [Labs #743](https://github.com/CommunityToolkit/Labs-Windows/pull/743), and [Tooling #296](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/296).

[Labs issue #741](https://github.com/CommunityToolkit/Labs-Windows/issues/741) tracked the original runner-image fallout.

## Problem

During the .NET 10 upgrade, the old mitigation became the new blocker. `windows-2022` still avoids the missing-SDK issue, but it cannot provide the VS2026/MSBuild 18 toolchain required by .NET 10. `windows-2025` provides the required VS2026/MSBuild 18 toolchain, but it reintroduces the missing Windows SDK issue that caused the original runner pin.

During the compatibility review, we also confirmed that changing the Windows target requirements is not the right fix. The shared tooling configuration still preserves older Windows target compatibility, including `TargetPlatformMinVersion` `10.0.17763.0`. Raising those requirements would turn a CI image dependency into a consumer-facing compatibility change.

## Solution

During the tooling update, we brought back the small [`Install-WindowsSdk.ps1`](https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/c8f76d072df53d3622fb5440d63afb06cb9e7a10/build/Install-WindowsSDK.ps1) script from the 7x Windows Community Toolkit build scripts.

During the workflow update, the CI jobs were moved back to `windows-2025` and a new `Install Windows SDKs` step was added before `microsoft/setup-msbuild`.

That gives CI both sides of the requirement:
- The current hosted image with VS2026/MSBuild 18 for .NET 10
- The explicit Windows SDK installation needed to preserve existing Windows target compatibility.

It also makes the SDK dependency explicit instead of depending on whichever SDK versions happen to be preinstalled on the runner image.

A more polished end-user SDK detection/install flow can be handled separately; this PR is intentionally scoped to unblocking CI on `windows-2025`.

Prerequisites to closing this PR:
- Blocked by https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/312
