### PR TITLE
Add Stretch for ContentAlignment on SettingsCard

### DIFF
--- a/components/SettingsControls/samples/SettingsPageExample.xaml
+++ b/components/SettingsControls/samples/SettingsPageExample.xaml
@@ -57,6 +57,16 @@
                         <controls:SettingsCard ContentAlignment="Left">
                             <CheckBox Content="Here the ContentAlignment is set to Left. This is great for e.g. CheckBoxes or RadioButtons" />
                         </controls:SettingsCard>
+                        <controls:SettingsCard ContentAlignment="Stretch">
+                            <Border>
+                                <StackPanel>
+                                    <TextBlock TextWrapping="WrapWholeWords"
+                                               Text="Here the ContentAlignment is set to Stretch, so the content fills the entire card. This is great for controls like Sliders that benefit from having more space." />
+                                    <Slider Margin="0,10,0,0"
+                                            HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                            </Border>
+                        </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
 

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
@@ -211,5 +211,10 @@ public enum ContentAlignment
     /// <summary>
     /// The Content is vertically aligned.
     /// </summary>
-    Vertical
+    Vertical,
+
+    /// <summary>
+    /// The Content stretches and fills all the available space.
+    /// </summary>
+    Stretch
 }

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -370,6 +370,22 @@
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource TemplatedParent}}" />
                                         </VisualState.Setters>
                                     </VisualState>
+
+                                    <!--  Union Left and Vertical, HeaderIcon/Header/Description collapsed, Content stretches and fills all the available space  -->
+                                    <VisualState x:Name="Stretch">
+                                        <VisualState.StateTriggers>
+                                            <tk:IsEqualStateTrigger Value="{Binding ContentAlignment, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                    To="Stretch" />
+                                        </VisualState.StateTriggers>
+                                        <VisualState.Setters>
+                                            <Setter Target="PART_HeaderIconPresenterHolder.Visibility" Value="Collapsed" />
+                                            <Setter Target="PART_DescriptionPresenter.Visibility" Value="Collapsed" />
+                                            <Setter Target="PART_HeaderPresenter.Visibility" Value="Collapsed" />
+                                            <Setter Target="PART_ContentPresenter.(Grid.Row)" Value="1" />
+                                            <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="1" />
+                                            <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
+                                        </VisualState.Setters>
+                                    </VisualState>
                                 </VisualStateGroup>
 
                                 <!--  Collapsing the Content presenter whenever it's empty  -->


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes
This PR extends `ContentAlignment`
<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?
+ New mode `Stretch` for settings card, which allows `Content` to use all available spaces and collapsed rest of UI elements
<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

<!-- - Bugfix -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
+ Supports only `Left`, `Right`, `Vertical` currently
+ `SettingsExpander.Items` do not accept custom controls except `SettingsCard` by default because [ItemContainerStyleSelector](https://github.com/CommunityToolkit/Windows/blob/b1d8231b5ee810f4e4264be17d9c343ee2785ede/components/SettingsControls/src/SettingsExpander/SettingsExpander.xaml#L72), even it supports, custom control still needs to simulate the paddings just like `SettingsCard` using `Padding="58,8,44,8"`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
+ New behavior creates the `SettingsCard` filled with `Content` within `SettingsExpander`
+ Provide a new way for developer to set custom layout/control under the `SettingsExpander` using `SettingsCard`
<img width="745" height="212" alt="image" src="https://github.com/user-attachments/assets/a5471fdb-710f-4223-9efb-0970d9daa6df" />

<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs
- [ ] New component
  - [ ] Documentation has been added
  - [ ] Sample in sample app has been added
  - [ ] Analyzers are passing for documentation and samples
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (if applicable)
- [x] Header has been added to all new source files
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
