### PR TITLE
Flipped default Settings Card Action Icon in RTL contexts

### DIFF
--- a/components/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
@@ -40,7 +40,7 @@ public partial class SettingsCard : ButtonBase
         nameof(ActionIcon),
         typeof(IconElement),
         typeof(SettingsCard),
-        new PropertyMetadata(defaultValue: "\ue974"));
+        new PropertyMetadata(defaultValue: null));
 
     /// <summary>
     /// The backing <see cref="DependencyProperty"/> for the <see cref="ActionIconToolTip"/> property.

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -66,6 +66,9 @@ public partial class SettingsCard : ButtonBase
     public SettingsCard()
     {
         this.DefaultStyleKey = typeof(SettingsCard);
+
+        // This is perhaps indicative of an issue with the action icon requiring a concrete FontElement instead of a template
+        ActionIcon = new FontIcon { Glyph = "\ue974", MirroredWhenRightToLeft = true };
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #846

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->
<!-- New features should come from Windows Community Toolkit Labs. If you're migrating a component from Labs, link to the approval comment here. -->

Bugfix 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

The default `ActionIcon` is a chevron that points right, regardless of the FlowDirection

## What is the new behavior?

The default `ActionIcon` is a chevron that points outwards, flipping based on the FlowDirection

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current supported SDKs(https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

I'm not terribly happy with this solution. I think this poor solution represents an issue that the action icon maybe should be templated.