### PR TITLE
Adopt Uno.Sdk tooling (Uno 6.x) for the WinUI 3 gallery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
       matrix:
         winui: [2, 3]
-        multitarget: ['uwp', 'wasdk', 'wasm', 'unosdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android']
+        multitarget: ['uwp', 'wasdk', 'wasm', 'wpf', 'win32', 'linux', 'macos', 'ios', 'android']
         exclude:
           # WinUI 2 not supported on wasdk
           - winui: 2
@@ -75,12 +75,18 @@ jobs:
           # WinUI 3 not supported on uwp
           - winui: 3
             multitarget: uwp
-          # WinUI 3 wasm is covered by the Uno.Sdk head (unosdk)
+          # wpf is the Uno 5 Skia WPF head, which Uno 6 replaced with win32
+          - winui: 3
+            multitarget: wpf
+          # win32 is the Uno 6 Skia desktop head, which has no Uno 5 equivalent
+          - winui: 2
+            multitarget: win32
+        include:
+          # On WinUI 3 the Uno.Sdk head replaces the classic Wasm head, so it rides on the
+          # existing wasm job as a flag rather than a fake entry in the multitarget axis.
           - winui: 3
             multitarget: wasm
-          # Uno.Sdk head is WinUI 3 only
-          - winui: 2
-            multitarget: unosdk
+            unoSdkHead: true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -118,7 +124,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Run Uno Check to Install Dependencies
-        if: ${{ matrix.multitarget != 'wasdk' && matrix.multitarget != 'linuxgtk' && matrix.multitarget != 'wpf' && matrix.multitarget != 'unosdk' }}
+        if: ${{ matrix.multitarget != 'wasdk' && matrix.multitarget != 'linux' && matrix.multitarget != 'wpf' && matrix.multitarget != 'win32' && !matrix.unoSdkHead }}
         run: >
           dotnet tool run uno-check
           --ci
@@ -134,7 +140,7 @@ jobs:
       # The Uno.Sdk head builds desktop/browserwasm/android (iOS is filtered on
       # Windows). Install the matching workloads directly instead of uno-check.
       - name: Install .NET workloads (Uno.Sdk head)
-        if: ${{ matrix.multitarget == 'unosdk' }}
+        if: ${{ matrix.unoSdkHead }}
         run: dotnet workload install wasm-tools android ios maui
 
       - name: Add msbuild to PATH
@@ -143,20 +149,14 @@ jobs:
           vs-version: '[17.9,)'
 
       # Generate full solution with all projects (sample gallery heads, components, tests)
+      # The Uno.Sdk head also covers Windows desktop, so it asks for win32 alongside wasm.
       - name: Generate solution with ${{ matrix.multitarget }} gallery, components and tests
-        if: ${{ matrix.multitarget != 'unosdk' }}
         working-directory: ./
-        run: powershell -version 5.1 -command "./tooling/GenerateAllSolution.ps1 -MultiTargets ${{ matrix.multitarget }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }} -WinUIMajorVersion ${{ matrix.winui }}" -ErrorAction Stop
-
-      # The Uno.Sdk head covers wasm (browserwasm) for WinUI 3; generate with it included
-      - name: Generate solution with Uno.Sdk gallery, components and tests
-        if: ${{ matrix.multitarget == 'unosdk' }}
-        working-directory: ./
-        run: powershell -version 5.1 -command "./tooling/GenerateAllSolution.ps1 -MultiTargets wasm -IncludeUnoSdkHead -WinUIMajorVersion 3${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}" -ErrorAction Stop
+        run: powershell -version 5.1 -command "./tooling/GenerateAllSolution.ps1 -MultiTargets ${{ matrix.multitarget }}${{ matrix.unoSdkHead && ',win32 -IncludeUnoSdkHead' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }} -WinUIMajorVersion ${{ matrix.winui }}" -ErrorAction Stop
 
       # Build solution
       - name: MSBuild
-        if: ${{ matrix.multitarget != 'unosdk' }}
+        if: ${{ !matrix.unoSdkHead }}
         run: >
           msbuild.exe /restore /nowarn:MSB4011
           /p:Configuration=Release
@@ -168,7 +168,7 @@ jobs:
       # The Uno.Sdk head is a single project covering desktop/browserwasm/android
       # (iOS is filtered on Windows); build it directly with dotnet.
       - name: Build Uno.Sdk head
-        if: ${{ matrix.multitarget == 'unosdk' }}
+        if: ${{ matrix.unoSdkHead }}
         run: dotnet build tooling/ProjectHeads/AllComponents/Uno/CommunityToolkit.App.Uno.csproj -p:Configuration=Release ${{ env.ENABLE_DIAGNOSTICS == 'true' && '/bl' || '' }}
 
       # Run tests
@@ -483,7 +483,7 @@ jobs:
       - name: Generate solution
         shell: pwsh
         working-directory: ./
-        run: ./tooling/GenerateAllSolution.ps1 -MultiTargets wasm -IncludeUnoSdkHead -WinUIMajorVersion 3${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}
+        run: ./tooling/GenerateAllSolution.ps1 -MultiTargets wasm,linux -IncludeUnoSdkHead -WinUIMajorVersion 3${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}
 
       - name: Build Uno head (browserwasm)
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
       matrix:
         winui: [2, 3]
-        multitarget: ['uwp', 'wasdk', 'wasm', 'wpf', 'linuxgtk', 'macos', 'ios', 'android']
+        multitarget: ['uwp', 'wasdk', 'wasm', 'unosdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android']
         exclude:
           # WinUI 2 not supported on wasdk
           - winui: 2
@@ -75,6 +75,12 @@ jobs:
           # WinUI 3 not supported on uwp
           - winui: 3
             multitarget: uwp
+          # WinUI 3 wasm is covered by the Uno.Sdk head (unosdk)
+          - winui: 3
+            multitarget: wasm
+          # Uno.Sdk head is WinUI 3 only
+          - winui: 2
+            multitarget: unosdk
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -112,9 +118,9 @@ jobs:
         run: dotnet tool restore
 
       - name: Run Uno Check to Install Dependencies
-        if: ${{ matrix.multitarget != 'wasdk' && matrix.multitarget != 'linuxgtk' && matrix.multitarget != 'wpf' }}
+        if: ${{ matrix.multitarget != 'wasdk' && matrix.multitarget != 'linuxgtk' && matrix.multitarget != 'wpf' && matrix.multitarget != 'unosdk' }}
         run: >
-          dotnet tool run uno-check 
+          dotnet tool run uno-check
           --ci
           --target ${{ matrix.multitarget }}
           --fix
@@ -125,6 +131,12 @@ jobs:
           --skip vswin
           --verbose
 
+      # The Uno.Sdk head builds desktop/browserwasm/android (iOS is filtered on
+      # Windows). Install the matching workloads directly instead of uno-check.
+      - name: Install .NET workloads (Uno.Sdk head)
+        if: ${{ matrix.multitarget == 'unosdk' }}
+        run: dotnet workload install wasm-tools android ios maui
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
         with:
@@ -132,11 +144,19 @@ jobs:
 
       # Generate full solution with all projects (sample gallery heads, components, tests)
       - name: Generate solution with ${{ matrix.multitarget }} gallery, components and tests
+        if: ${{ matrix.multitarget != 'unosdk' }}
         working-directory: ./
         run: powershell -version 5.1 -command "./tooling/GenerateAllSolution.ps1 -MultiTargets ${{ matrix.multitarget }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }} -WinUIMajorVersion ${{ matrix.winui }}" -ErrorAction Stop
 
+      # The Uno.Sdk head covers wasm (browserwasm) for WinUI 3; generate with it included
+      - name: Generate solution with Uno.Sdk gallery, components and tests
+        if: ${{ matrix.multitarget == 'unosdk' }}
+        working-directory: ./
+        run: powershell -version 5.1 -command "./tooling/GenerateAllSolution.ps1 -MultiTargets wasm -IncludeUnoSdkHead -WinUIMajorVersion 3${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}" -ErrorAction Stop
+
       # Build solution
       - name: MSBuild
+        if: ${{ matrix.multitarget != 'unosdk' }}
         run: >
           msbuild.exe /restore /nowarn:MSB4011
           /p:Configuration=Release
@@ -144,6 +164,12 @@ jobs:
           ${{ env.ENABLE_DIAGNOSTICS == 'true' && '/bl' || '' }}
           /v:${{ env.MSBUILD_VERBOSITY }}
           CommunityToolkit.AllComponents.sln
+
+      # The Uno.Sdk head is a single project covering desktop/browserwasm/android
+      # (iOS is filtered on Windows); build it directly with dotnet.
+      - name: Build Uno.Sdk head
+        if: ${{ matrix.multitarget == 'unosdk' }}
+        run: dotnet build tooling/ProjectHeads/AllComponents/Uno/CommunityToolkit.App.Uno.csproj -p:Configuration=Release ${{ env.ENABLE_DIAGNOSTICS == 'true' && '/bl' || '' }}
 
       # Run tests
       - name: Setup VSTest Path
@@ -424,7 +450,7 @@ jobs:
           --api-key ${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}
           --skip-duplicate
 
-  wasm-linux:
+  uno-linux:
     runs-on: ubuntu-latest
 
     steps:
@@ -439,6 +465,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      # iOS/maccatalyst aren't installable on Linux (Uno.Sdk filters those TFMs
+      # there). android + wasm-tools are both required: even a single-TFM build
+      # restores all of the head's TargetFrameworks, validating net9.0-android.
+      - name: Install .NET workloads
+        run: dotnet workload install android wasm-tools
+
       - name: .NET Info (if diagnostics)
         if: ${{ env.ENABLE_DIAGNOSTICS == 'true' }}
         run: dotnet --info
@@ -447,31 +479,26 @@ jobs:
       - name: Restore dotnet tools
         run: dotnet tool restore
 
-      - name: Enable WASM TargetFrameworks
-        shell: pwsh
-        working-directory: ./${{ env.MULTI_TARGET_DIRECTORY }}
-        run: ./UseTargetFrameworks.ps1 wasm
-
+      # Generate the full solution with the Uno.Sdk gallery head, components and tests
       - name: Generate solution
         shell: pwsh
         working-directory: ./
-        run: ./tooling/GenerateAllSolution.ps1${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}
+        run: ./tooling/GenerateAllSolution.ps1 -MultiTargets wasm -IncludeUnoSdkHead -WinUIMajorVersion 3${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}
 
-      - name: Install ninja for WASM native dependencies
-        run: sudo apt-get install ninja-build
+      - name: Build Uno head (browserwasm)
+        shell: pwsh
+        working-directory: ./
+        run: dotnet build tooling/ProjectHeads/AllComponents/Uno/CommunityToolkit.App.Uno.csproj -f net9.0-browserwasm -p:Configuration=Release
 
-      # Issue with Comment Links currently, see: https://github.com/mrlacey/CommentLinks/issues/38
-      # See launch.json configuration file for analogous command we're emulating here to build LINK: ../../.vscode/launch.json:CommunityToolkit.App.Wasm.csproj
-      - name: dotnet build
-        working-directory: ./${{ env.HEADS_DIRECTORY }}/AllComponents/Wasm/
-        run: dotnet build /r /bl -v:${{ env.MSBUILD_VERBOSITY }}
-  
-      # TODO: Do we want to run tests here? Can we do that on linux easily?
+      - name: Build Uno head (desktop)
+        shell: pwsh
+        working-directory: ./
+        run: dotnet build tooling/ProjectHeads/AllComponents/Uno/CommunityToolkit.App.Uno.csproj -f net9.0-desktop -p:Configuration=Release
 
       - name: Artifact - Diagnostic Logs
         uses: actions/upload-artifact@v4
         if: ${{ (env.ENABLE_DIAGNOSTICS == 'true' || env.COREHOST_TRACE != '') && always() }}
         with:
-          name: linux-logs
+          name: uno-linux-logs
           path: ./**/*.*log
 

--- a/components/Animations/src/MultiTarget.props
+++ b/components/Animations/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Animations/src/Xaml/Abstract/Animation{TValue,TKeyFrame}.cs
+++ b/components/Animations/src/Xaml/Abstract/Animation{TValue,TKeyFrame}.cs
@@ -30,11 +30,14 @@ public abstract class Animation<TValue, TKeyFrame> : Animation
     /// <summary>
     /// Identifies the <seealso cref="To"/> dependency property.
     /// </summary>
+    // typeof(TValue?) is only used as dependency property metadata, not for reflective construction.
+#pragma warning disable IL2087
     public static readonly DependencyProperty ToProperty = DependencyProperty.Register(
         nameof(To),
         typeof(TValue?),
         typeof(Animation<TValue, TKeyFrame>),
         new PropertyMetadata(null));
+#pragma warning restore IL2087
 
     /// <summary>
     /// Gets or sets the optional starting value for the animation.
@@ -48,11 +51,14 @@ public abstract class Animation<TValue, TKeyFrame> : Animation
     /// <summary>
     /// Identifies the <seealso cref="From"/> dependency property.
     /// </summary>
+    // typeof(TValue?) is only used as dependency property metadata, not for reflective construction.
+#pragma warning disable IL2087
     public static readonly DependencyProperty FromProperty = DependencyProperty.Register(
         nameof(From),
         typeof(TValue?),
         typeof(Animation<TValue, TKeyFrame>),
         new PropertyMetadata(null));
+#pragma warning restore IL2087
 
     /// <summary>
     /// Gets or sets the optional keyframe collection for the current animation.

--- a/components/Animations/src/Xaml/Abstract/KeyFrame{TValue,TKeyFrame}.cs
+++ b/components/Animations/src/Xaml/Abstract/KeyFrame{TValue,TKeyFrame}.cs
@@ -60,11 +60,14 @@ public abstract partial class KeyFrame<TValue, TKeyFrame> : KeyFrame, IKeyFrame<
     /// <summary>
     /// Identifies the <seealso cref="Value"/> dependency property.
     /// </summary>
+    // typeof(TValue?) is only used as dependency property metadata, not for reflective construction.
+#pragma warning disable IL2087
     public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
         nameof(Value),
         typeof(TValue?),
         typeof(KeyFrame<TValue, TKeyFrame>),
         new PropertyMetadata(null));
+#pragma warning restore IL2087
 
     /// <summary>
     /// Gets or sets the optional expression for the current keyframe.

--- a/components/Behaviors/src/Headers/HeaderBehaviorBase.cs
+++ b/components/Behaviors/src/Headers/HeaderBehaviorBase.cs
@@ -184,7 +184,10 @@ public abstract class HeaderBehaviorBase : BehaviorBase<FrameworkElement>
         }
         else
         {
+            // Obsolete on WinUI 3/Uno, but required as a fallback where XamlRoot is unavailable (e.g. UWP).
+#pragma warning disable CS0618
             focusedElement = FocusManager.GetFocusedElement()!;
+#pragma warning restore CS0618
         }
 
         // To prevent Popups (Flyouts...) from triggering the autoscroll, we check if the focused element has a valid parent.

--- a/components/Behaviors/src/MultiTarget.props
+++ b/components/Behaviors/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Collections/src/MultiTarget.props
+++ b/components/Collections/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/ColorPicker/src/MultiTarget.props
+++ b/components/ColorPicker/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Converters/src/MultiTarget.props
+++ b/components/Converters/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/DeveloperTools/src/FocusTracker/FocusTracker.cs
+++ b/components/DeveloperTools/src/FocusTracker/FocusTracker.cs
@@ -83,7 +83,10 @@ public partial class FocusTracker : Control
         }
         else
         {
+            // Obsolete on WinUI 3/Uno, but required as a fallback where XamlRoot is unavailable (e.g. UWP).
+#pragma warning disable CS0618
             if (FocusManager.GetFocusedElement() is FrameworkElement element)
+#pragma warning restore CS0618
             {
                 FocusOnControl(element);
             }

--- a/components/DeveloperTools/src/MultiTarget.props
+++ b/components/DeveloperTools/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Extensions/src/MultiTarget.props
+++ b/components/Extensions/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/HeaderedControls/src/MultiTarget.props
+++ b/components/HeaderedControls/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Helpers/src/MultiTarget.props
+++ b/components/Helpers/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/LayoutTransformControl/src/MultiTarget.props
+++ b/components/LayoutTransformControl/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/MetadataControl/src/MultiTarget.props
+++ b/components/MetadataControl/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Primitives/src/MultiTarget.props
+++ b/components/Primitives/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/RangeSelector/src/MultiTarget.props
+++ b/components/RangeSelector/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Segmented/src/MultiTarget.props
+++ b/components/Segmented/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/Segmented/src/Segmented/Segmented.cs
+++ b/components/Segmented/src/Segmented/Segmented.cs
@@ -116,7 +116,10 @@ public partial class Segmented : ListViewBase
         }
         else
         {
+            // Obsolete on WinUI 3/Uno, but required as a fallback where XamlRoot is unavailable (e.g. UWP).
+#pragma warning disable CS0618
             return FocusManager.GetFocusedElement() as SegmentedItem;
+#pragma warning restore CS0618
         }
     }
 

--- a/components/SettingsControls/src/MultiTarget.props
+++ b/components/SettingsControls/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -322,7 +322,10 @@ public partial class SettingsCard : ButtonBase
         }
         else
         {
+            // Obsolete on WinUI 3/Uno, but required as a fallback where XamlRoot is unavailable (e.g. UWP).
+#pragma warning disable CS0618
             return FocusManager.GetFocusedElement() as FrameworkElement;
+#pragma warning restore CS0618
         }
     }
 

--- a/components/Sizers/src/MultiTarget.props
+++ b/components/Sizers/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/TabbedCommandBar/src/MultiTarget.props
+++ b/components/TabbedCommandBar/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/TokenizingTextBox/src/MultiTarget.props
+++ b/components/TokenizingTextBox/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>

--- a/components/TokenizingTextBox/src/TokenizingTextBox.Selection.cs
+++ b/components/TokenizingTextBox/src/TokenizingTextBox.Selection.cs
@@ -141,7 +141,10 @@ FocusManager.TryMoveFocus(FocusNavigationDirection.Previous, new FindNextElement
         }
         else
         {
+            // Obsolete on WinUI 3/Uno, but required as a fallback where XamlRoot is unavailable (e.g. UWP).
+#pragma warning disable CS0618
             return FocusManager.GetFocusedElement() as TokenizingTextBoxItem;
+#pragma warning restore CS0618
         }
     }
 

--- a/components/TokenizingTextBox/src/TokenizingTextBox.cs
+++ b/components/TokenizingTextBox/src/TokenizingTextBox.cs
@@ -361,7 +361,10 @@ public partial class TokenizingTextBox : ListViewBase
         }
         else
         {
+            // Obsolete on WinUI 3/Uno, but required as a fallback where XamlRoot is unavailable (e.g. UWP).
+#pragma warning disable CS0618
             return FocusManager.GetFocusedElement()!;
+#pragma warning restore CS0618
         }
     }
 

--- a/components/Triggers/src/MultiTarget.props
+++ b/components/Triggers/src/MultiTarget.props
@@ -4,6 +4,6 @@
           MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
           Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
         -->
-        <MultiTarget>uwp;wasdk;wpf;wasm;linuxgtk;macos;ios;android;</MultiTarget>
+        <MultiTarget>uwp;wasdk;wpf;win32;wasm;linux;macos;ios;android;</MultiTarget>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Transitions the toolkit to the Uno.Sdk-based tooling, building the WinUI 3 sample gallery through the unified Uno.Sdk head (desktop + browserwasm + android) while keeping Uno.UI 5.x for UWP / WinUI 2.

Depends on the tooling submodule PR: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/305 (which in turn depends on #304). The submodule pointer here references that branch and will move to the merged commit once #305 lands.

## Changes
- Bump the `tooling` submodule to the Uno.Sdk-based version.
- Fix warnings (treated as errors) surfaced by Uno 6.x when the Uno.Sdk head compiles the components for `net9.0`:
  - **CS0618**: `FocusManager.GetFocusedElement()` is obsolete on WinUI 3/Uno — suppress the no-arg fallback used where `XamlRoot` is unavailable (UWP).
  - **IL2087**: trim analysis on generic `DependencyProperty.Register` in the Animations base types (the type is only used as DP metadata).
- **CI**: build the Uno.Sdk head for WinUI 3 — add an `unosdk` entry to the Windows `build` matrix (excluding `winui3 + wasm`) and replace the `wasm-linux` job with `uno-linux` (browserwasm + desktop). WinUI 2 (UWP) keeps the legacy Uno.UI 5.x wasm head.

Both Uno.Sdk heads (`net9.0-desktop` and `net9.0-browserwasm`) build end-to-end against the toolkit components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)