### PR TITLE
[Duplicate] Flipped default Settings Card Action Icon in RTL contexts

### DIFF
--- a/components/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
@@ -40,7 +40,7 @@ public partial class SettingsCard : ButtonBase
         nameof(ActionIcon),
         typeof(IconElement),
         typeof(SettingsCard),
-        new PropertyMetadata(defaultValue: "\ue974"));
+        new PropertyMetadata(defaultValue: null));
 
     /// <summary>
     /// The backing <see cref="DependencyProperty"/> for the <see cref="ActionIconToolTip"/> property.

--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -66,6 +66,9 @@ public partial class SettingsCard : ButtonBase
     public SettingsCard()
     {
         this.DefaultStyleKey = typeof(SettingsCard);
+
+        // This is perhaps indicative of an issue with the action icon requiring a concrete FontElement instead of a template
+        ActionIcon = new FontIcon { Glyph = "\ue974", MirroredWhenRightToLeft = true };
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This PR is a duplicate of #855 created to (hopefully) resolve CLI issues.